### PR TITLE
fix(ui): Scrollbar overlays expando buttons

### DIFF
--- a/packages/userscript/source/ui/UserInterface.ts
+++ b/packages/userscript/source/ui/UserInterface.ts
@@ -144,6 +144,7 @@ export class UserInterface {
     this._addRule(
       `#ks {
         margin-bottom: 10px;
+        padding-right: 10px;
       }`
     );
     this._addRule(


### PR DESCRIPTION
On the default theme, the UI is hard to use, because the scrollbar overlays the expando buttons on hover.