### PR TITLE
fix(village): Not all jobs/traits are assigned as leaders

### DIFF
--- a/packages/userscript/source/settings/ElectLeaderSettings.ts
+++ b/packages/userscript/source/settings/ElectLeaderSettings.ts
@@ -23,7 +23,7 @@ export class ElectLeaderSettings extends Setting {
       { label: "Chemist", value: "chemist" },
       { label: "Manager", value: "manager" },
       { label: "Merchant", value: "merchant" },
-      { label: "Metallurgist", value: "matallurgist" },
+      { label: "Metallurgist", value: "metallurgist" },
       { label: "Philosopher", value: "wise" },
       { label: "Scientist", value: "scientist" },
       { label: "None", value: "none" },

--- a/packages/userscript/source/settings/Settings.ts
+++ b/packages/userscript/source/settings/Settings.ts
@@ -131,7 +131,7 @@ export class SettingOptions<T = string> {
 
   constructor(selected: T, options = new Array<{ label: string; value: T }>()) {
     // Make sure the provided selected value exists in options.
-    if (isNil(options.find(option => (option.value = selected)))) {
+    if (isNil(options.find(option => option.value === selected))) {
       throw new Error("Provided selected value is not in provided options.");
     }
 

--- a/packages/userscript/source/types/index.ts
+++ b/packages/userscript/source/types/index.ts
@@ -96,7 +96,7 @@ export type Trait =
   | "chemist"
   | "engineer"
   | "manager"
-  | "matallurgist"
+  | "metallurgist"
   | "merchant"
   | "none"
   | "scientist"


### PR DESCRIPTION
Some jobs and traits, when selected as leader, would not have any effect.

Fixes https://github.com/kitten-science/kitten-scientists/issues/104