### PR TITLE
ci: Generate release info

### DIFF
--- a/.github/workflows/release-info.yml
+++ b/.github/workflows/release-info.yml
@@ -1,0 +1,40 @@
+name: Update Release Info
+
+on:
+  schedule:
+    - cron: 0 4 * * *
+  workflow_dispatch:
+
+concurrency: release-info
+
+jobs:
+  release-info:
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+      - run: yarn install --immutable
+      - run: yarn workspace @kitten-science/action-release-info tsc --build
+
+      - uses: ./packages/action-release-info
+        with:
+          filename: release-info.json
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GitHubActions
+
+      - name: Deploy to S3
+        run: |
+          aws s3 cp release-info.json s3://${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/userscript-nightly.yml
+++ b/.github/workflows/userscript-nightly.yml
@@ -46,8 +46,11 @@ jobs:
       - run: yarn lint:all
       - run: yarn typecheck:all
 
+      - name: Get version
+        run: |
+          export KS_VERSION=$(yarn userscript:version)
+          echo "KS_VERSION=$KS_VERSION" >> $GITHUB_ENV
       - run: yarn userscript:release
-
       - uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           automatic_release_tag: nightly
@@ -56,4 +59,4 @@ jobs:
             packages/userscript/output/*
           prerelease: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          title: Nightly Build
+          title: Nightly Build ${{ env.KS_VERSION }}

--- a/.github/workflows/userscript-publish.yml
+++ b/.github/workflows/userscript-publish.yml
@@ -28,8 +28,11 @@ jobs:
       - run: yarn lint:all
       - run: yarn typecheck:all
 
+      - name: Get version
+        run: |
+          export KS_VERSION=$(yarn userscript:version)
+          echo "KS_VERSION=$KS_VERSION" >> $GITHUB_ENV
       - run: yarn userscript:release
-
       - uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           automatic_release_tag: next
@@ -38,4 +41,4 @@ jobs:
             packages/userscript/output/*
           prerelease: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          title: Development Build
+          title: Development Build ${{ env.KS_VERSION }}

--- a/packages/action-release-info/action.yml
+++ b/packages/action-release-info/action.yml
@@ -1,0 +1,16 @@
+name: Release Info Generator
+description: Builds and publishes a file that contains relevant information about Kitten Scientists releases.
+author: Oliver Salzburg
+inputs:
+  filename:
+    default: ""
+    description: |
+      The name of the file into which to write the release info.
+      Release info is still printed to console if `filename` is empty.
+    required: false
+  repo_token:
+    description: Needs `secrets.GITHUB_TOKEN` to talk to the API.
+    required: true
+runs:
+  using: node16
+  main: output/main.mjs

--- a/packages/action-release-info/package.json
+++ b/packages/action-release-info/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "name": "@kitten-science/action-release-info",
+  "version": "latest",
+  "license": "MIT",
+  "author": "Oliver Salzburg <oliver.salzburg@gmail.com>",
+  "homepage": "https://github.com/kitten-science/kitten-scientists",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kitten-science/kitten-scientists.git",
+    "directory": "packages/action-release-info"
+  },
+  "bugs": {
+    "url": "https://github.com/kitten-science/kitten-scientists/issues"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./output/index.mjs"
+  },
+  "types": "./output/index.d.mts",
+  "dependencies": {
+    "@actions/core": "1.10.0",
+    "@actions/github": "5.1.1",
+    "tslib": "2.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.14",
+    "typescript": "4.9.4"
+  }
+}

--- a/packages/action-release-info/source/ReleaseInfo.mts
+++ b/packages/action-release-info/source/ReleaseInfo.mts
@@ -1,0 +1,45 @@
+export type ReleaseMeta = {
+  /**
+   * The version string of the release.
+   */
+  version: string;
+
+  /**
+   * When was this release created?
+   */
+  date: string;
+
+  url: {
+    /**
+     * A URL that points to the userscript.
+     */
+    default: string;
+
+    /**
+     * The same userscript, but minified.
+     */
+    minified: string;
+
+    /**
+     * Points to the GitHub release for this version.
+     */
+    release: string;
+  };
+};
+
+export type ReleaseInfo = {
+  /**
+   * The latest stable release.
+   */
+  stable: ReleaseMeta;
+
+  /**
+   * The nightly build.
+   */
+  nightly: ReleaseMeta;
+
+  /**
+   * The development build.
+   */
+  dev: ReleaseMeta;
+};

--- a/packages/action-release-info/source/main.mts
+++ b/packages/action-release-info/source/main.mts
@@ -1,0 +1,82 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { writeFileSync } from "fs";
+import { ReleaseInfo } from "./ReleaseInfo.mjs";
+
+async function run() {
+  const token = core.getInput("repo_token", { required: true });
+  const octokit = github.getOctokit(token);
+
+  let latestStableVersion = "v2.0.0-beta.3";
+
+  core.info("Looking for dev build...");
+  const latestBuildDev = await octokit.rest.repos.getReleaseByTag({
+    owner: "kitten-science",
+    repo: "kitten-scientists",
+    tag: "next",
+  });
+
+  core.info("Looking for nightly build...");
+  const latestBuildNightly = await octokit.rest.repos.getReleaseByTag({
+    owner: "kitten-science",
+    repo: "kitten-scientists",
+    tag: "nightly",
+  });
+
+  core.info("Looking for stable build...");
+  const latestBuildStable = await octokit.rest.repos.getReleaseByTag({
+    owner: "kitten-science",
+    repo: "kitten-scientists",
+    tag: latestStableVersion,
+  });
+  latestBuildDev.data.assets[1].name;
+
+  const releaseInfo: ReleaseInfo = {
+    dev: {
+      version: "0.0.0",
+      date: latestBuildDev.data.created_at,
+      url: {
+        default: findUserscript(latestBuildDev.data.assets)!.browser_download_url,
+        minified: findUserscript(latestBuildDev.data.assets, true)!.browser_download_url,
+        release: latestBuildDev.data.html_url,
+      },
+    },
+    nightly: {
+      version: "0.0.0",
+      date: latestBuildNightly.data.created_at,
+      url: {
+        default: findUserscript(latestBuildNightly.data.assets)!.browser_download_url,
+        minified: findUserscript(latestBuildNightly.data.assets, true)!.browser_download_url,
+        release: latestBuildNightly.data.html_url,
+      },
+    },
+    stable: {
+      version: latestBuildStable.data.tag_name,
+      date: latestBuildStable.data.created_at,
+      url: {
+        default: findUserscript(latestBuildStable.data.assets)!.browser_download_url,
+        minified: findUserscript(latestBuildStable.data.assets, true)!.browser_download_url,
+        release: latestBuildStable.data.html_url,
+      },
+    },
+  };
+
+  const filename = core.getInput("filename", { required: false });
+  if (filename !== "") {
+    writeFileSync(filename, JSON.stringify(releaseInfo, undefined, 2));
+  }
+
+  console.dir(releaseInfo);
+}
+
+function findUserscript<TAsset extends { name: string }>(
+  assets: Array<TAsset>,
+  minified = false
+): TAsset | undefined {
+  return assets.find(
+    asset =>
+      asset.name.startsWith("kitten-scientists-") && asset.name.includes(".min.") === minified
+  );
+}
+
+void run();

--- a/packages/action-release-info/tsconfig.json
+++ b/packages/action-release-info/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "isolatedModules": true,
+    "outDir": "output",
+    "rootDir": "source"
+  },
+  "include": ["../../@types", "source"],
+  "references": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,6 +724,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@kitten-science/action-release-info@workspace:packages/action-release-info":
+  version: 0.0.0-use.local
+  resolution: "@kitten-science/action-release-info@workspace:packages/action-release-info"
+  dependencies:
+    "@actions/core": 1.10.0
+    "@actions/github": 5.1.1
+    "@types/node": ^18.11.14
+    tslib: 2.4.1
+    typescript: 4.9.4
+  languageName: unknown
+  linkType: soft
+
 "@kitten-science/documentation@workspace:packages/documentation":
   version: 0.0.0-use.local
   resolution: "@kitten-science/documentation@workspace:packages/documentation"


### PR DESCRIPTION
We now publish a metadata file that contains information about the different KS releases. This could later be used to indicate available updates to users.