### PR TITLE
feat(workshop): Simplify resource crafting

### DIFF
--- a/packages/documentation/docs/sections/bonfire.md
+++ b/packages/documentation/docs/sections/bonfire.md
@@ -5,7 +5,9 @@
 When you enable a building, this building will be built if all of these are true:
 
 1. Less than **Max** buildings have already been built.
+
 1. _All_ of the resources required for the building to built are filled to **Trigger** of their stock capacity.
+
 1. _All_ of the resources required for the building to built are sufficiently available after considering configured **Stock** and **Consume**.
 
 ### Upgrades

--- a/packages/documentation/docs/sections/village.md
+++ b/packages/documentation/docs/sections/village.md
@@ -26,4 +26,4 @@ Promotes your leader, as soon as possible.
 
 ### Elect leader
 
-Elects a kittens with the given attributes as a leader.
+Elects a kitten with the given attributes as a leader.

--- a/packages/documentation/docs/sections/workshop.md
+++ b/packages/documentation/docs/sections/workshop.md
@@ -1,1 +1,45 @@
 # Workshop
+
+## Resource Crafting
+
+In general, resources are crafted if they are enabled and less than **Max** resources are already in stock.
+
+Additionally, if crafting a resource requires one or more materials that have a capacity, those materials need to be filled to **Trigger** of their stock capacity.
+
+!!! example
+
+    **Wood** has a capacity. If you want to craft **Beams**, and you set a trigger of `0.5`, then beams would be crafted if wood is filled to half of its stock capacity.
+
+    When you want to craft **Megaliths**, they are built from **Beams**, **Slabs**, and **Plates**. All of which have _no capacity_. So the trigger value does not apply to this craft.
+
+### Unlimited Crafting
+
+Just craft as many items as possible, respecting your [Resource Control configuration](./resource-control.md).
+
+### Limited Crafting
+
+For a limited item to be crafted, we first look at all the materials that are required for the item to be crafted, and at our current stock for the item. We then calculate how much of our materials would be required to build all the items _we already have in stock_. If we have more materials than _that_, then we allow the additional materials to be crafted into more of the craftable item.
+
+!!! example
+
+    Let's assume you want to craft **Beams**. A beam costs 175 **Wood**, and you have 1 beam in stock. KS would then craft the next beam when you have 350 wood available.
+
+### Force Ships to 243
+
+When enabled, **Trade Ships** will be handled as _unlimited_, regardless of the actual configuration, until you have at least 243 ships in stock.
+
+!!! quote
+
+    Having 243 or more ships will guarantee that you get titanium from a trade. The exact number is `1700/7` ships, which rounds up to 243.
+
+    <https://wiki.kittensgame.com/en/general-information/resources/ship>
+
+## Research Upgrades
+
+Selected upgrades will automatically be researched as soon as possible.
+
+<!-- prettier-ignore-start -->
+*[KG]: Kittens Game
+*[KS]: Kitten Scientists
+*[UI]: User interface
+<!-- prettier-ignore-end -->

--- a/packages/documentation/mkdocs.yml
+++ b/packages/documentation/mkdocs.yml
@@ -1,4 +1,4 @@
-copyright: Oliver Salzburg
+copyright: Oliver Salzburg and Kitten Science Contributors
 dev_addr: 0.0.0.0:8000
 docs_dir: docs
 extra:

--- a/packages/userscript/source/settings/WorkshopSettings.ts
+++ b/packages/userscript/source/settings/WorkshopSettings.ts
@@ -1,22 +1,15 @@
 import { consumeEntriesPedantic } from "../tools/Entries";
 import { isNil, Maybe } from "../tools/Maybe";
 import { GamePage, ResourceCraftable } from "../types";
-import { Requirement, Setting, SettingLimitedMax, SettingTrigger } from "./Settings";
+import { Setting, SettingLimitedMax, SettingTrigger } from "./Settings";
 import { UpgradeSettings } from "./UpgradeSettings";
 
 export class CraftSettingsItem extends SettingLimitedMax {
   readonly resource: ResourceCraftable;
-  require: Requirement;
 
-  constructor(
-    resource: ResourceCraftable,
-    require: Requirement = false,
-    enabled = true,
-    limited = true
-  ) {
+  constructor(resource: ResourceCraftable, enabled = true, limited = true) {
     super(enabled, limited);
     this.resource = resource;
-    this.require = require;
   }
 }
 
@@ -32,25 +25,25 @@ export class WorkshopSettings extends SettingTrigger {
     enabled = false,
     trigger = 0.95,
     resources: WorkshopResourceSettings = {
-      alloy: new CraftSettingsItem("alloy", "titanium"),
-      beam: new CraftSettingsItem("beam", "wood"),
-      blueprint: new CraftSettingsItem("blueprint", "science"),
-      compedium: new CraftSettingsItem("compedium", "science"),
-      concrate: new CraftSettingsItem("concrate", false),
-      eludium: new CraftSettingsItem("eludium", "unobtainium"),
-      gear: new CraftSettingsItem("gear", false),
-      kerosene: new CraftSettingsItem("kerosene", "oil"),
-      manuscript: new CraftSettingsItem("manuscript", "culture"),
-      megalith: new CraftSettingsItem("megalith", false),
-      parchment: new CraftSettingsItem("parchment", false, true, false),
-      plate: new CraftSettingsItem("plate", "iron"),
-      scaffold: new CraftSettingsItem("scaffold", false),
-      ship: new CraftSettingsItem("ship", false),
-      slab: new CraftSettingsItem("slab", "minerals"),
-      steel: new CraftSettingsItem("steel", "coal"),
-      tanker: new CraftSettingsItem("tanker", false),
-      thorium: new CraftSettingsItem("thorium", "uranium"),
-      wood: new CraftSettingsItem("wood", "catnip"),
+      alloy: new CraftSettingsItem("alloy"),
+      beam: new CraftSettingsItem("beam"),
+      blueprint: new CraftSettingsItem("blueprint"),
+      compedium: new CraftSettingsItem("compedium"),
+      concrate: new CraftSettingsItem("concrate"),
+      eludium: new CraftSettingsItem("eludium"),
+      gear: new CraftSettingsItem("gear"),
+      kerosene: new CraftSettingsItem("kerosene"),
+      manuscript: new CraftSettingsItem("manuscript"),
+      megalith: new CraftSettingsItem("megalith"),
+      parchment: new CraftSettingsItem("parchment", true, false),
+      plate: new CraftSettingsItem("plate"),
+      scaffold: new CraftSettingsItem("scaffold"),
+      ship: new CraftSettingsItem("ship"),
+      slab: new CraftSettingsItem("slab"),
+      steel: new CraftSettingsItem("steel"),
+      tanker: new CraftSettingsItem("tanker"),
+      thorium: new CraftSettingsItem("thorium"),
+      wood: new CraftSettingsItem("wood"),
     },
     unlockUpgrades = new UpgradeSettings(),
     shipOverride = new Setting(true)

--- a/packages/userscript/source/ui/WorkshopSettingsUi.ts
+++ b/packages/userscript/source/ui/WorkshopSettingsUi.ts
@@ -1,7 +1,6 @@
 import { CraftSettingsItem, WorkshopSettings } from "../settings/WorkshopSettings";
 import { UserScript } from "../UserScript";
 import { TriggerButton } from "./components/buttons-icon/TriggerButton";
-import { HeaderListItem } from "./components/HeaderListItem";
 import { SettingLimitedMaxListItem } from "./components/SettingLimitedMaxListItem";
 import { SettingListItem } from "./components/SettingListItem";
 import { SettingsList } from "./components/SettingsList";
@@ -10,8 +9,6 @@ import { UpgradeSettingsUi } from "./UpgradeSettingsUi";
 
 export class WorkshopSettingsUi extends SettingsSectionUi<WorkshopSettings> {
   private readonly _trigger: TriggerButton;
-  private readonly _upgradeUi: UpgradeSettingsUi;
-  private readonly _shipOverride: SettingListItem;
 
   constructor(host: UserScript, settings: WorkshopSettings) {
     const label = host.engine.i18n("ui.craft");
@@ -63,6 +60,22 @@ export class WorkshopSettingsUi extends SettingsSectionUi<WorkshopSettings> {
           this.setting.resources.ship,
           this._host.engine.i18n("$workshop.crafts.ship.label")
         ),
+        new SettingListItem(
+          this._host,
+          this._host.engine.i18n("option.shipOverride"),
+          this.setting.shipOverride,
+          {
+            onCheck: () =>
+              this._host.engine.imessage("status.sub.enable", [
+                this._host.engine.i18n("option.shipOverride"),
+              ]),
+            onUnCheck: () =>
+              this._host.engine.imessage("status.sub.disable", [
+                this._host.engine.i18n("option.shipOverride"),
+              ]),
+            upgradeIndicator: true,
+          }
+        ),
         this._getCraftOption(
           this.setting.resources.tanker,
           this._host.engine.i18n("$workshop.crafts.tanker.label"),
@@ -111,32 +124,13 @@ export class WorkshopSettingsUi extends SettingsSectionUi<WorkshopSettings> {
     });
     this.addChild(listCrafts);
 
-    const listAdditional = new SettingsList(this._host, {
-      hasDisableAll: false,
-      hasEnableAll: false,
-    });
-    listAdditional.addChild(new HeaderListItem(this._host, "Additional options"));
-
-    this._upgradeUi = new UpgradeSettingsUi(this._host, this.setting.unlockUpgrades);
-    listAdditional.addChild(this._upgradeUi);
-
-    this._shipOverride = new SettingListItem(
-      this._host,
-      this._host.engine.i18n("option.shipOverride"),
-      this.setting.shipOverride,
-      {
-        onCheck: () =>
-          this._host.engine.imessage("status.sub.enable", [
-            this._host.engine.i18n("option.shipOverride"),
-          ]),
-        onUnCheck: () =>
-          this._host.engine.imessage("status.sub.disable", [
-            this._host.engine.i18n("option.shipOverride"),
-          ]),
-      }
+    this.addChild(
+      new SettingsList(this._host, {
+        children: [new UpgradeSettingsUi(this._host, this.setting.unlockUpgrades)],
+        hasDisableAll: false,
+        hasEnableAll: false,
+      })
     );
-    listAdditional.addChild(this._shipOverride);
-    this.addChild(listAdditional);
   }
 
   private _getCraftOption(


### PR DESCRIPTION
There was some edge case handling to balance production between plates and steel, which seems entirely redundant, given the balancing behavior of limited crafting.

The trigger applied to some hardcoded material, only a single one, and only for some crafts. This could cause unintuitive crafting behavior.

Even if the trigger wasn't hit, a resource could still be crafted under certain conditions.

The behavior of limited crafting was inconsistent.

The way resource crafting behaves now, should be far more intuitive and consistent. Additionally, it has now been documented.