### PR TITLE
feat(core): Remove hardcoded build requirements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
     "biolab",
     "Blackcoin",
     "blackcoins",
+    "broadcasttower",
     "browserstack",
     "bulkmanager",
     "calciner",

--- a/packages/userscript/source/WorkshopManager.ts
+++ b/packages/userscript/source/WorkshopManager.ts
@@ -107,18 +107,23 @@ export class WorkshopManager extends UpgradeManager implements Automation {
 
       const materials = Object.keys(this.getMaterials(craft.resource)) as Array<Resource>;
       // The resource information for the requirement of this craft which have a capacity.
-      const require = materials
+      const requiredMaterials = materials
         .map(material => this.getResource(material))
         .filter(material => 0 < material.maxValue);
 
       const allMaterialsAboveTrigger =
-        require.filter(material => material.value / material.maxValue < trigger).length === 0;
+        requiredMaterials.filter(material => material.value / material.maxValue < trigger)
+          .length === 0;
 
       if (!allMaterialsAboveTrigger) {
         continue;
       }
 
-      const amount = this.getLowestCraftAmount(craft.resource, craft.limited, 0 < require.length);
+      const amount = this.getLowestCraftAmount(
+        craft.resource,
+        craft.limited,
+        0 < requiredMaterials.length
+      );
 
       // If we can craft any of this item, do it.
       if (0 < amount) {

--- a/packages/userscript/source/settings/BonfireSettings.ts
+++ b/packages/userscript/source/settings/BonfireSettings.ts
@@ -2,7 +2,7 @@ import { consumeEntriesPedantic } from "../tools/Entries";
 import { isNil, Maybe } from "../tools/Maybe";
 import { Building } from "../types";
 import { BuildingUpgradeSettings } from "./BuildingUpgradeSettings";
-import { Requirement, Setting, SettingMax, SettingTrigger } from "./Settings";
+import { Setting, SettingMax, SettingTrigger } from "./Settings";
 
 /**
  * One of the building options in the KS menu.
@@ -19,11 +19,6 @@ export class BonfireBuildingSetting extends SettingMax {
   readonly baseBuilding: Building | undefined = undefined;
 
   readonly building: BonfireItem;
-
-  /**
-   * A resource that you must have unlocked to build this.
-   */
-  readonly require: Requirement = false;
 
   /**
    * In case this is an upgradable building, this indicates the level of

--- a/packages/userscript/source/settings/ReligionSettings.ts
+++ b/packages/userscript/source/settings/ReligionSettings.ts
@@ -1,7 +1,7 @@
 import { consumeEntriesPedantic } from "../tools/Entries";
 import { isNil, Maybe } from "../tools/Maybe";
 import { UnicornItemVariant } from "../types";
-import { Requirement, Setting, SettingMax, SettingTrigger } from "./Settings";
+import { Setting, SettingMax, SettingTrigger } from "./Settings";
 
 export type FaithItem =
   | "apocripha"
@@ -42,19 +42,16 @@ export type ReligionAdditionItem = "adore" | "autoPraise" | "bestUnicornBuilding
 
 export class ReligionSettingsItem extends SettingMax {
   readonly building: FaithItem | UnicornItem;
-  readonly require: Requirement;
   readonly variant: UnicornItemVariant;
 
   constructor(
     building: FaithItem | UnicornItem,
     variant: UnicornItemVariant,
     enabled = false,
-    max = -1,
-    require: Requirement = false
+    max = -1
   ) {
     super(enabled, max);
     this.building = building;
-    this.require = require;
     this.variant = variant;
   }
 }
@@ -105,215 +102,130 @@ export class ReligionSettings extends SettingTrigger {
     enabled = false,
     trigger = 1,
     buildings: ReligionSettingsItems = {
-      apocripha: new ReligionSettingsItem(
-        "apocripha",
-        UnicornItemVariant.OrderOfTheSun,
-        false,
-        -1,
-        "faith"
-      ),
-      basilica: new ReligionSettingsItem(
-        "basilica",
-        UnicornItemVariant.OrderOfTheSun,
-        true,
-        -1,
-        "faith"
-      ),
+      apocripha: new ReligionSettingsItem("apocripha", UnicornItemVariant.OrderOfTheSun, false, -1),
+      basilica: new ReligionSettingsItem("basilica", UnicornItemVariant.OrderOfTheSun, true, -1),
       blackCore: new ReligionSettingsItem(
         "blackCore",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
       blackLibrary: new ReligionSettingsItem(
         "blackLibrary",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
       blackNexus: new ReligionSettingsItem(
         "blackNexus",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
       blackObelisk: new ReligionSettingsItem(
         "blackObelisk",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
       blackPyramid: new ReligionSettingsItem(
         "blackPyramid",
         UnicornItemVariant.Ziggurat,
         false,
-        -1,
-        "unobtainium"
+        -1
       ),
       blackRadiance: new ReligionSettingsItem(
         "blackRadiance",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
-      blazar: new ReligionSettingsItem(
-        "blazar",
-        UnicornItemVariant.Cryptotheology,
-        false,
-        -1,
-        false
-      ),
-      darkNova: new ReligionSettingsItem(
-        "darkNova",
-        UnicornItemVariant.Cryptotheology,
-        false,
-        -1,
-        false
-      ),
+      blazar: new ReligionSettingsItem("blazar", UnicornItemVariant.Cryptotheology, false, -1),
+      darkNova: new ReligionSettingsItem("darkNova", UnicornItemVariant.Cryptotheology, false, -1),
       goldenSpire: new ReligionSettingsItem(
         "goldenSpire",
         UnicornItemVariant.OrderOfTheSun,
         true,
-        -1,
-        "faith"
+        -1
       ),
       holyGenocide: new ReligionSettingsItem(
         "holyGenocide",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
       ivoryCitadel: new ReligionSettingsItem(
         "ivoryCitadel",
         UnicornItemVariant.Ziggurat,
         false,
-        -1,
-        false
+        -1
       ),
-      ivoryTower: new ReligionSettingsItem(
-        "ivoryTower",
-        UnicornItemVariant.Ziggurat,
-        false,
-        -1,
-        false
-      ),
-      marker: new ReligionSettingsItem(
-        "marker",
-        UnicornItemVariant.Ziggurat,
-        false,
-        -1,
-        "unobtainium"
-      ),
+      ivoryTower: new ReligionSettingsItem("ivoryTower", UnicornItemVariant.Ziggurat, false, -1),
+      marker: new ReligionSettingsItem("marker", UnicornItemVariant.Ziggurat, false, -1),
       scholasticism: new ReligionSettingsItem(
         "scholasticism",
         UnicornItemVariant.OrderOfTheSun,
         true,
-        -1,
-        "faith"
+        -1
       ),
       singularity: new ReligionSettingsItem(
         "singularity",
         UnicornItemVariant.Cryptotheology,
         false,
-        -1,
-        false
+        -1
       ),
-      skyPalace: new ReligionSettingsItem(
-        "skyPalace",
-        UnicornItemVariant.Ziggurat,
-        false,
-        -1,
-        false
-      ),
+      skyPalace: new ReligionSettingsItem("skyPalace", UnicornItemVariant.Ziggurat, false, -1),
       solarchant: new ReligionSettingsItem(
         "solarchant",
         UnicornItemVariant.OrderOfTheSun,
         true,
-        -1,
-        "faith"
+        -1
       ),
       solarRevolution: new ReligionSettingsItem(
         "solarRevolution",
         UnicornItemVariant.OrderOfTheSun,
         true,
-        -1,
-        "faith"
+        -1
       ),
       stainedGlass: new ReligionSettingsItem(
         "stainedGlass",
         UnicornItemVariant.OrderOfTheSun,
         true,
-        -1,
-        "faith"
+        -1
       ),
-      sunAltar: new ReligionSettingsItem(
-        "sunAltar",
-        UnicornItemVariant.OrderOfTheSun,
-        true,
-        -1,
-        "faith"
-      ),
-      sunspire: new ReligionSettingsItem(
-        "sunspire",
-        UnicornItemVariant.Ziggurat,
-        false,
-        -1,
-        "gold"
-      ),
-      templars: new ReligionSettingsItem(
-        "templars",
-        UnicornItemVariant.OrderOfTheSun,
-        true,
-        -1,
-        "faith"
-      ),
+      sunAltar: new ReligionSettingsItem("sunAltar", UnicornItemVariant.OrderOfTheSun, true, -1),
+      sunspire: new ReligionSettingsItem("sunspire", UnicornItemVariant.Ziggurat, false, -1),
+      templars: new ReligionSettingsItem("templars", UnicornItemVariant.OrderOfTheSun, true, -1),
       transcendence: new ReligionSettingsItem(
         "transcendence",
         UnicornItemVariant.OrderOfTheSun,
         true,
-        -1,
-        "faith"
+        -1
       ),
       unicornGraveyard: new ReligionSettingsItem(
         "unicornGraveyard",
         UnicornItemVariant.Ziggurat,
         false,
-        -1,
-        false
+        -1
       ),
       unicornNecropolis: new ReligionSettingsItem(
         "unicornNecropolis",
         UnicornItemVariant.Ziggurat,
         false,
-        -1,
-        false
+        -1
       ),
       unicornPasture: new ReligionSettingsItem(
         "unicornPasture",
         UnicornItemVariant.UnicornPasture,
         true,
-        -1,
-        false
+        -1
       ),
-      unicornTomb: new ReligionSettingsItem(
-        "unicornTomb",
-        UnicornItemVariant.Ziggurat,
-        false,
-        -1,
-        false
-      ),
+      unicornTomb: new ReligionSettingsItem("unicornTomb", UnicornItemVariant.Ziggurat, false, -1),
       unicornUtopia: new ReligionSettingsItem(
         "unicornUtopia",
         UnicornItemVariant.Ziggurat,
         false,
-        -1,
-        "gold"
+        -1
       ),
     },
     bestUnicornBuilding = new Setting(false),

--- a/packages/userscript/source/settings/TimeSettings.ts
+++ b/packages/userscript/source/settings/TimeSettings.ts
@@ -1,7 +1,7 @@
 import { consumeEntriesPedantic } from "../tools/Entries";
 import { isNil, Maybe } from "../tools/Maybe";
 import { ChronoForgeUpgrades, TimeItemVariant, VoidSpaceUpgrades } from "../types";
-import { Requirement, Setting, SettingMax, SettingTrigger } from "./Settings";
+import { Setting, SettingMax, SettingTrigger } from "./Settings";
 
 /**
  * The upgrades on the Time tab that we have options for.
@@ -10,18 +10,11 @@ export type TimeItem = Exclude<ChronoForgeUpgrades | VoidSpaceUpgrades, "usedCry
 
 export class TimeSettingsItem extends SettingMax {
   readonly building: TimeItem;
-  readonly require: Requirement;
   readonly variant: TimeItemVariant;
 
-  constructor(
-    building: TimeItem,
-    variant: TimeItemVariant,
-    require: Requirement = false,
-    enabled = false
-  ) {
+  constructor(building: TimeItem, variant: TimeItemVariant, enabled = false) {
     super(enabled);
     this.building = building;
-    this.require = require;
     this.variant = variant;
   }
 }
@@ -39,18 +32,14 @@ export class TimeSettings extends SettingTrigger {
     trigger = 1,
     buildings: TimeBuildingsSettings = {
       blastFurnace: new TimeSettingsItem("blastFurnace", TimeItemVariant.Chronoforge),
-      chronocontrol: new TimeSettingsItem(
-        "chronocontrol",
-        TimeItemVariant.VoidSpace,
-        "temporalFlux"
-      ),
+      chronocontrol: new TimeSettingsItem("chronocontrol", TimeItemVariant.VoidSpace),
       cryochambers: new TimeSettingsItem("cryochambers", TimeItemVariant.VoidSpace),
       ressourceRetrieval: new TimeSettingsItem("ressourceRetrieval", TimeItemVariant.Chronoforge),
       temporalAccelerator: new TimeSettingsItem("temporalAccelerator", TimeItemVariant.Chronoforge),
       temporalBattery: new TimeSettingsItem("temporalBattery", TimeItemVariant.Chronoforge),
       temporalImpedance: new TimeSettingsItem("temporalImpedance", TimeItemVariant.Chronoforge),
       timeBoiler: new TimeSettingsItem("timeBoiler", TimeItemVariant.Chronoforge),
-      voidHoover: new TimeSettingsItem("voidHoover", TimeItemVariant.VoidSpace, "antimatter"),
+      voidHoover: new TimeSettingsItem("voidHoover", TimeItemVariant.VoidSpace),
       voidResonator: new TimeSettingsItem("voidResonator", TimeItemVariant.VoidSpace),
       voidRift: new TimeSettingsItem("voidRift", TimeItemVariant.VoidSpace),
     },


### PR DESCRIPTION
Previously, builds would optionally define a single required resource. This resource would be the only one taken into consideration for the trigger value.

Now, this hardcoded requirement has been removed and the trigger applies to all source materials that have a capacity.