### PR TITLE
feat(core): Remove redundant state fields

### DIFF
--- a/packages/userscript/source/settings/BonfireSettings.ts
+++ b/packages/userscript/source/settings/BonfireSettings.ts
@@ -16,23 +16,32 @@ export class BonfireBuildingSetting extends SettingMax {
    * In case this is an upgrade of another building, this is the name of the
    * base building.
    */
-  readonly baseBuilding: Building | undefined = undefined;
+  readonly #baseBuilding: Building | undefined = undefined;
+  get baseBuilding() {
+    return this.#baseBuilding;
+  }
 
-  readonly building: BonfireItem;
+  readonly #building: BonfireItem;
+  get building() {
+    return this.#building;
+  }
 
   /**
    * In case this is an upgradable building, this indicates the level of
    * the stage.
    */
-  readonly stage: number = 0;
+  readonly #stage: number = 0;
+  get stage() {
+    return this.#stage;
+  }
 
   constructor(building: BonfireItem, enabled = false, max = -1, baseStage?: Building) {
     super(enabled, max);
 
-    this.building = building;
+    this.#building = building;
     if (baseStage) {
-      this.stage = 1;
-      this.baseBuilding = baseStage;
+      this.#stage = 1;
+      this.#baseBuilding = baseStage;
     }
   }
 }

--- a/packages/userscript/source/settings/BuildingUpgradeSettings.ts
+++ b/packages/userscript/source/settings/BuildingUpgradeSettings.ts
@@ -4,11 +4,15 @@ import { StagedBuilding } from "../types";
 import { Setting } from "./Settings";
 
 export class BuildingUpgradeSetting extends Setting {
-  readonly upgrade: StagedBuilding;
+  readonly #upgrade: StagedBuilding;
+
+  get upgrade() {
+    return this.#upgrade;
+  }
 
   constructor(upgrade: StagedBuilding, enabled = false) {
     super(enabled);
-    this.upgrade = upgrade;
+    this.#upgrade = upgrade;
   }
 }
 

--- a/packages/userscript/source/settings/EmbassySettings.ts
+++ b/packages/userscript/source/settings/EmbassySettings.ts
@@ -4,11 +4,15 @@ import { Race } from "../types";
 import { SettingMax, SettingTrigger } from "./Settings";
 
 export class EmbassySetting extends SettingMax {
-  readonly race: Race;
+  readonly #race: Race;
+
+  get race() {
+    return this.#race;
+  }
 
   constructor(race: Race, enabled = false) {
     super(enabled);
-    this.race = race;
+    this.#race = race;
   }
 }
 

--- a/packages/userscript/source/settings/LogFilterSettings.ts
+++ b/packages/userscript/source/settings/LogFilterSettings.ts
@@ -42,11 +42,15 @@ export type FilterItem =
   | "upgradeFilter";
 
 export class LogFilterSettingsItem extends Setting {
-  variant: LogFilterItemVariant;
+  readonly #variant: LogFilterItemVariant;
+
+  get variant() {
+    return this.#variant;
+  }
 
   constructor(variant: LogFilterItemVariant) {
     super(true);
-    this.variant = variant;
+    this.#variant = variant;
   }
 }
 

--- a/packages/userscript/source/settings/MissionSettings.ts
+++ b/packages/userscript/source/settings/MissionSettings.ts
@@ -6,11 +6,15 @@ import { GamePage, Missions } from "../types";
 import { Setting } from "./Settings";
 
 export class MissionSetting extends Setting {
-  readonly mission: Missions;
+  readonly #mission: Missions;
+
+  get mission() {
+    return this.#mission;
+  }
 
   constructor(mission: Missions, enabled = false) {
     super(enabled);
-    this.mission = mission;
+    this.#mission = mission;
   }
 }
 

--- a/packages/userscript/source/settings/PolicySettings.ts
+++ b/packages/userscript/source/settings/PolicySettings.ts
@@ -6,11 +6,15 @@ import { GamePage, Policy } from "../types";
 import { Setting } from "./Settings";
 
 export class PolicySetting extends Setting {
-  readonly policy: Policy;
+  readonly #policy: Policy;
+
+  get policy() {
+    return this.#policy;
+  }
 
   constructor(policy: Policy, enabled = false) {
     super(enabled);
-    this.policy = policy;
+    this.#policy = policy;
   }
 }
 

--- a/packages/userscript/source/settings/ReligionSettings.ts
+++ b/packages/userscript/source/settings/ReligionSettings.ts
@@ -41,8 +41,15 @@ export type ReligionItem = FaithItem | UnicornItem;
 export type ReligionAdditionItem = "adore" | "autoPraise" | "bestUnicornBuilding" | "transcend";
 
 export class ReligionSettingsItem extends SettingMax {
-  readonly building: FaithItem | UnicornItem;
-  readonly variant: UnicornItemVariant;
+  readonly #building: FaithItem | UnicornItem;
+  readonly #variant: UnicornItemVariant;
+
+  get building() {
+    return this.#building;
+  }
+  get variant() {
+    return this.#variant;
+  }
 
   constructor(
     building: FaithItem | UnicornItem,
@@ -51,8 +58,8 @@ export class ReligionSettingsItem extends SettingMax {
     max = -1
   ) {
     super(enabled, max);
-    this.building = building;
-    this.variant = variant;
+    this.#building = building;
+    this.#variant = variant;
   }
 }
 

--- a/packages/userscript/source/settings/ResetBonfireSettings.ts
+++ b/packages/userscript/source/settings/ResetBonfireSettings.ts
@@ -4,11 +4,15 @@ import { BonfireItem } from "./BonfireSettings";
 import { Setting, SettingTrigger } from "./Settings";
 
 export class ResetBonfireBuildingSetting extends SettingTrigger {
-  readonly building: BonfireItem;
+  readonly #building: BonfireItem;
+
+  get building() {
+    return this.#building;
+  }
 
   constructor(building: BonfireItem, enabled = false, trigger = 1) {
     super(enabled, trigger);
-    this.building = building;
+    this.#building = building;
   }
 }
 

--- a/packages/userscript/source/settings/ResetReligionSettings.ts
+++ b/packages/userscript/source/settings/ResetReligionSettings.ts
@@ -5,8 +5,15 @@ import { FaithItem, UnicornItem } from "./ReligionSettings";
 import { Setting, SettingTrigger } from "./Settings";
 
 export class ResetReligionBuildingSetting extends SettingTrigger {
-  readonly building: FaithItem | UnicornItem;
-  readonly variant: UnicornItemVariant;
+  readonly #building: FaithItem | UnicornItem;
+  readonly #variant: UnicornItemVariant;
+
+  get building() {
+    return this.#building;
+  }
+  get variant() {
+    return this.#variant;
+  }
 
   constructor(
     building: FaithItem | UnicornItem,
@@ -15,8 +22,8 @@ export class ResetReligionBuildingSetting extends SettingTrigger {
     trigger = 1
   ) {
     super(enabled, trigger);
-    this.building = building;
-    this.variant = variant;
+    this.#building = building;
+    this.#variant = variant;
   }
 }
 

--- a/packages/userscript/source/settings/ResetResourcesSettings.ts
+++ b/packages/userscript/source/settings/ResetResourcesSettings.ts
@@ -4,12 +4,16 @@ import { Resource } from "../types";
 import { Setting } from "./Settings";
 
 export class ResetResourcesSettingsItem extends Setting {
-  readonly resource: Resource;
+  readonly #resource: Resource;
   stock = 0;
 
-  constructor(id: Resource, enabled: boolean, stock: number) {
+  get resource() {
+    return this.#resource;
+  }
+
+  constructor(resource: Resource, enabled: boolean, stock: number) {
     super(enabled);
-    this.resource = id;
+    this.#resource = resource;
     this.stock = stock;
   }
 }

--- a/packages/userscript/source/settings/ResetSpaceSettings.ts
+++ b/packages/userscript/source/settings/ResetSpaceSettings.ts
@@ -4,11 +4,15 @@ import { SpaceBuildings } from "../types";
 import { Setting, SettingTrigger } from "./Settings";
 
 export class ResetSpaceBuildingSetting extends SettingTrigger {
-  readonly building: SpaceBuildings;
+  readonly #building: SpaceBuildings;
+
+  get building() {
+    return this.#building;
+  }
 
   constructor(building: SpaceBuildings, enabled = false, trigger = 1) {
     super(enabled, trigger);
-    this.building = building;
+    this.#building = building;
   }
 }
 

--- a/packages/userscript/source/settings/ResetTimeSettings.ts
+++ b/packages/userscript/source/settings/ResetTimeSettings.ts
@@ -5,13 +5,20 @@ import { Setting, SettingTrigger } from "./Settings";
 import { TimeItem } from "./TimeSettings";
 
 export class ResetTimeBuildingSetting extends SettingTrigger {
-  readonly building: TimeItem;
-  readonly variant: TimeItemVariant;
+  readonly #building: TimeItem;
+  readonly #variant: TimeItemVariant;
+
+  get building() {
+    return this.#building;
+  }
+  get variant() {
+    return this.#variant;
+  }
 
   constructor(id: TimeItem, variant: TimeItemVariant, enabled = false, trigger = 1) {
     super(enabled, trigger);
-    this.building = id;
-    this.variant = variant;
+    this.#building = id;
+    this.#variant = variant;
   }
 }
 

--- a/packages/userscript/source/settings/ResourcesSettings.ts
+++ b/packages/userscript/source/settings/ResourcesSettings.ts
@@ -5,18 +5,22 @@ import { WorkshopManager } from "../WorkshopManager";
 import { Setting } from "./Settings";
 
 export class ResourcesSettingsItem extends Setting {
-  readonly resource: Resource;
+  readonly #resource: Resource;
   consume: number;
   stock = 0;
 
+  get resource() {
+    return this.#resource;
+  }
+
   constructor(
-    id: Resource,
+    resource: Resource,
     enabled: boolean,
     consume = WorkshopManager.DEFAULT_CONSUME_RATE,
     stock = 0
   ) {
     super(enabled);
-    this.resource = id;
+    this.#resource = resource;
     this.consume = consume;
     this.stock = stock;
   }

--- a/packages/userscript/source/settings/SpaceSettings.ts
+++ b/packages/userscript/source/settings/SpaceSettings.ts
@@ -5,10 +5,15 @@ import { MissionSettings } from "./MissionSettings";
 import { SettingMax, SettingTrigger } from "./Settings";
 
 export class SpaceBuildingSetting extends SettingMax {
-  readonly building: SpaceBuildings;
+  readonly #building: SpaceBuildings;
+
+  get building() {
+    return this.#building;
+  }
+
   constructor(building: SpaceBuildings, enabled = false) {
     super(enabled);
-    this.building = building;
+    this.#building = building;
   }
 }
 

--- a/packages/userscript/source/settings/TechSettings.ts
+++ b/packages/userscript/source/settings/TechSettings.ts
@@ -6,11 +6,15 @@ import { GamePage, Technology } from "../types";
 import { Setting } from "./Settings";
 
 export class TechSetting extends Setting {
-  readonly tech: Technology;
+  readonly #tech: Technology;
+
+  get tech() {
+    return this.#tech;
+  }
 
   constructor(tech: Technology, enabled = false) {
     super(enabled);
-    this.tech = tech;
+    this.#tech = tech;
   }
 }
 

--- a/packages/userscript/source/settings/TimeSettings.ts
+++ b/packages/userscript/source/settings/TimeSettings.ts
@@ -9,13 +9,20 @@ import { Setting, SettingMax, SettingTrigger } from "./Settings";
 export type TimeItem = Exclude<ChronoForgeUpgrades | VoidSpaceUpgrades, "usedCryochambers">;
 
 export class TimeSettingsItem extends SettingMax {
-  readonly building: TimeItem;
-  readonly variant: TimeItemVariant;
+  readonly #building: TimeItem;
+  readonly #variant: TimeItemVariant;
+
+  get building() {
+    return this.#building;
+  }
+  get variant() {
+    return this.#variant;
+  }
 
   constructor(building: TimeItem, variant: TimeItemVariant, enabled = false) {
     super(enabled);
-    this.building = building;
-    this.variant = variant;
+    this.#building = building;
+    this.#variant = variant;
   }
 }
 

--- a/packages/userscript/source/settings/TradeSettings.ts
+++ b/packages/userscript/source/settings/TradeSettings.ts
@@ -11,13 +11,20 @@ import {
 } from "./Settings";
 
 export class TradeSettingsItem extends SettingLimited {
-  readonly race: Race;
+  readonly #race: Race;
   readonly seasons: Record<Season, Setting>;
 
   /**
    * A resource that is required to trade with the race.
    */
-  require: Requirement;
+  readonly #require: Requirement;
+
+  get race() {
+    return this.#race;
+  }
+  get require() {
+    return this.#require;
+  }
 
   constructor(
     race: Race,
@@ -30,14 +37,14 @@ export class TradeSettingsItem extends SettingLimited {
     require: Requirement = false
   ) {
     super(enabled, limited);
-    this.race = race;
+    this.#race = race;
     this.seasons = {
       summer: new Setting(summer),
       autumn: new Setting(autumn),
       winter: new Setting(winter),
       spring: new Setting(spring),
     };
-    this.require = require;
+    this.#require = require;
   }
 }
 

--- a/packages/userscript/source/settings/UpgradeSettings.ts
+++ b/packages/userscript/source/settings/UpgradeSettings.ts
@@ -6,11 +6,15 @@ import { GamePage, Upgrade } from "../types";
 import { Setting } from "./Settings";
 
 export class UpgradeSetting extends Setting {
-  readonly upgrade: Upgrade;
+  readonly #upgrade: Upgrade;
+
+  get upgrade() {
+    return this.#upgrade;
+  }
 
   constructor(upgrade: Upgrade, enabled = false) {
     super(enabled);
-    this.upgrade = upgrade;
+    this.#upgrade = upgrade;
   }
 }
 

--- a/packages/userscript/source/settings/WorkshopSettings.ts
+++ b/packages/userscript/source/settings/WorkshopSettings.ts
@@ -5,11 +5,15 @@ import { Setting, SettingLimitedMax, SettingTrigger } from "./Settings";
 import { UpgradeSettings } from "./UpgradeSettings";
 
 export class CraftSettingsItem extends SettingLimitedMax {
-  readonly resource: ResourceCraftable;
+  readonly #resource: ResourceCraftable;
+
+  get resource() {
+    return this.#resource;
+  }
 
   constructor(resource: ResourceCraftable, enabled = true, limited = true) {
     super(enabled, limited);
-    this.resource = resource;
+    this.#resource = resource;
   }
 }
 


### PR DESCRIPTION
State snapshots now contain only your settings. Previously, they would also contain internals, that shouldn't be modified anyway.

The size of state snapshots has been reduced from ~34KB to ~17KB, about 50% smaller.