### PR TITLE
fix(time): Cryochambers are not built

### DIFF
--- a/packages/userscript/source/TimeManager.ts
+++ b/packages/userscript/source/TimeManager.ts
@@ -151,8 +151,7 @@ export class TimeManager {
     }
 
     for (const button of buttons) {
-      const haystack = button.model.name;
-      if (haystack.indexOf(build.label) !== -1) {
+      if (button.model.name.startsWith(build.label)) {
         return button as BuildButton<string, ButtonModernModel, ButtonModernController>;
       }
     }


### PR DESCRIPTION
The internal search for the right button model was imprecise. It would look at the model for the "Fix Cryochambers" button, instead of the Cryochambers one, because the name was similar enough.

Fixes #117