### PR TITLE
fix(workshop): Consume rate not applied consistently

### DIFF
--- a/packages/userscript/source/WorkshopManager.ts
+++ b/packages/userscript/source/WorkshopManager.ts
@@ -197,7 +197,9 @@ export class WorkshopManager extends UpgradeManager implements Automation {
             ? materialCraft.max - materialResource.value < 1
             : false) ||
           // Handle the ship override.
-          (craft.resource === "ship" && this.settings.shipOverride.enabled)
+          (craft.resource === "ship" &&
+            this.settings.shipOverride.enabled &&
+            this.getResource("ship").value < 243)
         ) {
           amount = Math.min(amount, material.consume / materialAmount);
           continue;


### PR DESCRIPTION
The consume rate was only applied to resources that have a capacity. The behavior also felt entirely inconsistent. Now, the consume rate is applied consistently, whenever a part of KS requests to know how much of a resource is available for use.