### PR TITLE
feat(time): Allow ignoring overheating for time skip

### DIFF
--- a/packages/documentation/docs/sections/time-control.md
+++ b/packages/documentation/docs/sections/time-control.md
@@ -17,6 +17,12 @@ For a skip to be triggered, all of these have to be true:
 
 KS will skip as many as the configured **Max** years.
 
+### Ignore overheat
+
+Usually, KS will not combust any more TCs when you have already reached your chrono heat capacity. When you have overheated your capacity, combusting any more TCs costs a premium.
+
+You can ignore this, when moving forward through time is more important than saving the time crystals.
+
 ## Reset Timeline
 
 This automation allows you to reset your entire game, when all your configured conditions are met.

--- a/packages/kitten-scientists/source/TimeControlManager.ts
+++ b/packages/kitten-scientists/source/TimeControlManager.ts
@@ -434,18 +434,23 @@ export class TimeControlManager {
     // If we have too much stored heat, wait for it to cool down.
     const heatMax = this._host.gamePage.getEffect("heatMax");
     const heatNow = this._host.gamePage.time.heat;
-    if (heatMax <= heatNow) {
-      return;
+    if (!this.settings.timeSkip.ignoreOverheat.enabled) {
+      if (heatMax <= heatNow) {
+        return;
+      }
     }
 
     const factor = this._host.gamePage.challenges.getChallenge("1000Years").researched ? 5 : 10;
-    // How many times/years we can skip before we reach our max heat.
+    // The maximum years to skip, based on the user configuration.
     const maxSkips =
       -1 === this.settings.timeSkip.max ? Number.POSITIVE_INFINITY : this.settings.timeSkip.max;
+
     // The amount of skips we can perform.
     let canSkip = Math.floor(
       Math.min(
-        (heatMax - heatNow) / factor,
+        this.settings.timeSkip.ignoreOverheat.enabled
+          ? Number.POSITIVE_INFINITY
+          : (heatMax - heatNow) / factor,
         maxSkips,
         timeCrystalsAvailable / (1 + shatterCostIncreaseChallenge),
         0 < shatterVoidCost ? voidAvailable / shatterVoidCost : Number.POSITIVE_INFINITY

--- a/packages/kitten-scientists/source/settings/TimeSkipSettings.ts
+++ b/packages/kitten-scientists/source/settings/TimeSkipSettings.ts
@@ -4,9 +4,9 @@ import { Cycle, Season } from "../types";
 import { Setting, SettingTriggerMax } from "./Settings";
 
 export class TimeSkipSettings extends SettingTriggerMax {
-  readonly seasons: Record<Season, Setting>;
-
   readonly cycles: Record<Cycle, Setting>;
+  readonly seasons: Record<Season, Setting>;
+  readonly ignoreOverheat: Setting;
 
   get cyclesList(): Array<Setting> {
     return [
@@ -41,11 +41,13 @@ export class TimeSkipSettings extends SettingTriggerMax {
       summer: new Setting(false),
       autumn: new Setting(false),
       winter: new Setting(false),
-    }
+    },
+    ignoreOverheat = new Setting(false)
   ) {
     super(false, 5);
-    this.seasons = seasons;
     this.cycles = cycles;
+    this.seasons = seasons;
+    this.ignoreOverheat = ignoreOverheat;
   }
 
   load(settings: Maybe<Partial<TimeSkipSettings>>) {
@@ -55,11 +57,12 @@ export class TimeSkipSettings extends SettingTriggerMax {
 
     super.load(settings);
 
-    consumeEntriesPedantic(this.seasons, settings.seasons, (season, item) => {
-      season.enabled = item?.enabled ?? season.enabled;
-    });
     consumeEntriesPedantic(this.cycles, settings.cycles, (cycle, item) => {
       cycle.enabled = item?.enabled ?? cycle.enabled;
     });
+    consumeEntriesPedantic(this.seasons, settings.seasons, (season, item) => {
+      season.enabled = item?.enabled ?? season.enabled;
+    });
+    this.ignoreOverheat.load(settings.ignoreOverheat);
   }
 }

--- a/packages/kitten-scientists/source/ui/TimeSkipSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/TimeSkipSettingsUi.ts
@@ -9,6 +9,7 @@ import { CyclesList } from "./components/CyclesList";
 import { LabelListItem } from "./components/LabelListItem";
 import { Panel } from "./components/Panel";
 import { SeasonsList } from "./components/SeasonsList";
+import { SettingListItem } from "./components/SettingListItem";
 import { SettingsList } from "./components/SettingsList";
 import { SettingsPanel, SettingsPanelOptions } from "./components/SettingsPanel";
 
@@ -64,6 +65,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings> {
           new ButtonListItem(host, this._maximum, { delimiter: true }),
           this._cycles,
           this._seasons,
+          new SettingListItem(this._host, "Ignore overheat", this.setting.ignoreOverheat),
         ],
         hasDisableAll: false,
         hasEnableAll: false,


### PR DESCRIPTION
KS will usually not combust TCs when you have accumulated too much chrono heat, as those combustions cost a premium. This options allows you to override that behavior, when skipping time is more important than preserving TCs.

Fixes #18