### PR TITLE
fix(core): Can't start when using non-English language

### DIFF
--- a/packages/kitten-scientists/source/Engine.ts
+++ b/packages/kitten-scientists/source/Engine.ts
@@ -98,7 +98,7 @@ export class Engine {
     this.settings = new EngineSettings();
 
     this._i18nData = i18nData;
-    this.setLanguage(gameLanguage);
+    this.setLanguage(gameLanguage, false);
 
     this._host = host;
     this._activitySummary = new ActivitySummary(this._host);
@@ -129,7 +129,7 @@ export class Engine {
     return language in this._i18nData;
   }
 
-  setLanguage(language: GameLanguage | SupportedLanguage) {
+  setLanguage(language: GameLanguage | SupportedLanguage, rebuildUI = true) {
     const previousLanguage = this.settings.language.selected;
     if (!this.isLanguageSupported(language)) {
       cwarn(
@@ -141,7 +141,7 @@ export class Engine {
       this.settings.language.selected = language as SupportedLanguage;
     }
 
-    if (previousLanguage !== this.settings.language.selected) {
+    if (previousLanguage !== this.settings.language.selected && rebuildUI) {
       this._host.rebuildUi();
     }
   }


### PR DESCRIPTION
skip rebuildUI in Engine constructor.

calling UserScript.rebuildUI in the constructor causing circular dependencies issue, since the Engine is needed for rebuildUI.

skip rebuildUI when setLanguage in the engine constructor, it will then set it again in stateLoad and call rebuildUI if needed.

fix #232 