### PR TITLE
fix(trade): Season selection is ignored

### DIFF
--- a/packages/kitten-scientists/source/TradeManager.ts
+++ b/packages/kitten-scientists/source/TradeManager.ts
@@ -77,7 +77,7 @@ export class TradeManager implements Automation {
       // Check if the race is enabled, in season, unlocked, and we can actually afford it.
       if (
         !trade.enabled ||
-        !trade.seasons[season] ||
+        !trade.seasons[season].enabled ||
         !race.unlocked ||
         !this.singleTradePossible(trade.race)
       ) {


### PR DESCRIPTION
Previously, setting any season filter for a race had no effect at all.

Fixes #210