### PR TITLE
feat(core): Implement new bulk purchase strategy

### DIFF
--- a/packages/kitten-scientists/source/BonfireManager.ts
+++ b/packages/kitten-scientists/source/BonfireManager.ts
@@ -77,7 +77,7 @@ export class BonfireManager implements Automation {
     }
 
     // Let the bulkmanager determine the builds we can make.
-    const buildList = bulkManager.bulk(builds, metaData, trigger, "bonfire");
+    const buildList = bulkManager.bulk(builds, metaData, trigger, "Bonfire");
 
     let refreshRequired = false;
     // Build all entries in the build list, where we can build any items.

--- a/packages/kitten-scientists/source/ReligionManager.ts
+++ b/packages/kitten-scientists/source/ReligionManager.ts
@@ -14,6 +14,7 @@ import {
   UnicornItem,
   UnicornItems,
 } from "./settings/ReligionSettings.js";
+import { negativeOneToInfinity } from "./tools/Format.js";
 import { cwarn } from "./tools/Log.js";
 import {
   BuildButton,
@@ -92,10 +93,7 @@ export class ReligionManager implements Automation {
         ),
       );
       // Build a unicorn pasture if possible.
-      const maxPastures =
-        -1 === this.settings.buildings.unicornPasture.max
-          ? Number.POSITIVE_INFINITY
-          : this.settings.buildings.unicornPasture.max;
+      const maxPastures = negativeOneToInfinity(this.settings.buildings.unicornPasture.max);
       const meta = this._host.game.bld.getBuildingExt("unicornPasture").meta;
       if (this.settings.buildings.unicornPasture.enabled && meta.val < maxPastures) {
         this._bonfireManager.autoBuild({
@@ -172,6 +170,7 @@ export class ReligionManager implements Automation {
         buildRequest,
         this.getBuildMetaData(buildRequest),
         this.settings.trigger,
+        "Religion",
       );
       if (0 < build.length && 0 < build[0].count) {
         // We force only building 1 of the best unicorn building, because
@@ -199,7 +198,7 @@ export class ReligionManager implements Automation {
     > = this.getBuildMetaData(builds);
 
     // Let the bulk manager figure out which of the builds to actually build.
-    const buildList = this._bulkManager.bulk(builds, metaData, this.settings.trigger);
+    const buildList = this._bulkManager.bulk(builds, metaData, this.settings.trigger, "Religion");
 
     let refreshRequired = false;
     for (const build of buildList) {

--- a/packages/kitten-scientists/source/SpaceManager.ts
+++ b/packages/kitten-scientists/source/SpaceManager.ts
@@ -72,7 +72,7 @@ export class SpaceManager implements Automation {
     }
 
     // Let the bulkmanager determine the builds we can make.
-    const buildList = bulkManager.bulk(builds, metaData, trigger, "space");
+    const buildList = bulkManager.bulk(builds, metaData, trigger, "Space");
 
     let refreshRequired = false;
     // Build all entries in the build list, where we can build any items.

--- a/packages/kitten-scientists/source/TimeControlManager.ts
+++ b/packages/kitten-scientists/source/TimeControlManager.ts
@@ -8,6 +8,7 @@ import { TabManager } from "./TabManager.js";
 import { WorkshopManager } from "./WorkshopManager.js";
 import { CycleIndices, TimeControlSettings } from "./settings/TimeControlSettings.js";
 import { objectEntries } from "./tools/Entries.js";
+import { negativeOneToInfinity } from "./tools/Format.js";
 import {
   BuildButton,
   ButtonModernController,
@@ -492,8 +493,7 @@ export class TimeControlManager {
     }
 
     // The maximum years to skip, based on the user configuration.
-    const maxSkips =
-      -1 === this.settings.timeSkip.max ? Number.POSITIVE_INFINITY : this.settings.timeSkip.max;
+    const maxSkips = negativeOneToInfinity(this.settings.timeSkip.max);
 
     // The amount of skips we can perform.
     let canSkip = Math.floor(

--- a/packages/kitten-scientists/source/TimeManager.ts
+++ b/packages/kitten-scientists/source/TimeManager.ts
@@ -90,7 +90,7 @@ export class TimeManager {
     }
 
     // Let the bulkmanager determine the builds we can make.
-    const buildList = bulkManager.bulk(builds, metaData, trigger);
+    const buildList = bulkManager.bulk(builds, metaData, trigger, "Time");
 
     let refreshRequired = false;
     for (const build of buildList) {

--- a/packages/kitten-scientists/source/TradeManager.ts
+++ b/packages/kitten-scientists/source/TradeManager.ts
@@ -6,7 +6,7 @@ import { WorkshopManager } from "./WorkshopManager.js";
 import { MaterialsCache } from "./helper/MaterialsCache.js";
 import { TradeSettings } from "./settings/TradeSettings.js";
 import { objectEntries } from "./tools/Entries.js";
-import { ucfirst } from "./tools/Format.js";
+import { negativeOneToInfinity, ucfirst } from "./tools/Format.js";
 import { cwarn } from "./tools/Log.js";
 import { BuildButton, Race, RaceInfo, Resource, TradeInfo, TradeTab } from "./types/index.js";
 
@@ -309,10 +309,7 @@ export class TradeManager implements Automation {
 
       const name = racePanels[panelIndex].race.name;
       const race = this._host.game.diplomacy.get(name);
-      const max =
-        this.settings.buildEmbassies.races[name].max === -1
-          ? Number.POSITIVE_INFINITY
-          : this.settings.buildEmbassies.races[name].max;
+      const max = negativeOneToInfinity(this.settings.buildEmbassies.races[name].max);
 
       if (
         !this.settings.buildEmbassies.races[name].enabled ||

--- a/packages/kitten-scientists/source/VillageManager.ts
+++ b/packages/kitten-scientists/source/VillageManager.ts
@@ -6,6 +6,7 @@ import { WorkshopManager } from "./WorkshopManager.js";
 import { MaterialsCache } from "./helper/MaterialsCache.js";
 import { VillageSettings } from "./settings/VillageSettings.js";
 import { objectEntries } from "./tools/Entries.js";
+import { negativeOneToInfinity } from "./tools/Format.js";
 import { Resource } from "./types/index.js";
 import { JobInfo, VillageTab } from "./types/village.js";
 
@@ -74,10 +75,7 @@ export class VillageManager implements Automation {
         }
 
         const maxKittensInJob = this._host.game.village.getJobLimit(job.name);
-        const maxKittensToAssign =
-          this.settings.jobs[job.name].max === -1
-            ? Number.POSITIVE_INFINITY
-            : this.settings.jobs[job.name].max;
+        const maxKittensToAssign = negativeOneToInfinity(this.settings.jobs[job.name].max);
         const kittensInJob = job.value;
         if (kittensInJob < maxKittensInJob && kittensInJob < maxKittensToAssign) {
           jobsNotCapped.push({ job, count: kittensInJob, toCap: maxKittensInJob - kittensInJob });

--- a/packages/kitten-scientists/source/WorkshopManager.ts
+++ b/packages/kitten-scientists/source/WorkshopManager.ts
@@ -5,6 +5,7 @@ import { KittenScientists } from "./KittenScientists.js";
 import { CraftSettingsItem, WorkshopSettings } from "./settings/WorkshopSettings.js";
 import { TabManager } from "./TabManager.js";
 import { objectEntries } from "./tools/Entries.js";
+import { negativeOneToInfinity } from "./tools/Format.js";
 import { cerror } from "./tools/Log.js";
 import { CraftableInfo, ResourceInfo } from "./types/craft.js";
 import { Resource, ResourceCraftable, UpgradeInfo } from "./types/index.js";
@@ -113,8 +114,7 @@ export class WorkshopManager extends UpgradeManager implements Automation {
       }
 
       const current = !craft.max ? false : this.getResource(craft.resource);
-
-      const max = craft.max === -1 ? Number.POSITIVE_INFINITY : craft.max;
+      const max = negativeOneToInfinity(craft.max);
       if (current && max < current.value) {
         continue;
       }

--- a/packages/kitten-scientists/source/tools/Format.ts
+++ b/packages/kitten-scientists/source/tools/Format.ts
@@ -15,3 +15,7 @@ export function ucfirst(input: string): string {
 export function roundToTwo(input: number): number {
   return Math.round(input * 100) / 100;
 }
+
+export function negativeOneToInfinity(value: number): number {
+  return value === -1 ? Number.POSITIVE_INFINITY : value;
+}


### PR DESCRIPTION
Many purchasing mechanisms in KS are driven by the "Bulk Purchase Helper". This component receives build requests, and is then expected to figure out how many items to build out of those requests. The helper works well enough, but has certain negative behaviors that most KS users will likely be aware of:

1. Build requests are always in the same order, as they are derived from your settings, which have a fixed order. The result is that certain items are _always_ built before other items. You will notice that certain buildings will only be built if another building becomes more expensive than itself.
2. When KS orders a large amount of certain items, a single build request can consume so many resources that no other build request can be satisfied. This can be especially painful after resets or during time skips.

The new behavior tries to fix these issues.

1. The helper loops over the requests several times to figure out a more ideal build solution.
2. When the helper processes the requests, it will randomize the order of requests during each loop iteration.
3. The helper will try to build 1 of each request during each iteration. If a build is possible, it will be ordered, and the remaining resources are recorded to evaluate the remaining build requests. If the build is _not_ possible, the build request is dropped; any prior successful build requests are still ordered though.

> [!WARNING]
> In the current working state, the helper produces build requests that can not be satisfied. The result is a log message like `Build Broadcast Tower (x0)`. This is under investigation and needs to be fixed before this feature can be merged.

Fixes #155 