### PR TITLE
fix(core): Inconsistent trigger handling

### DIFF
--- a/packages/kitten-scientists/source/settings/ReligionSettings.ts
+++ b/packages/kitten-scientists/source/settings/ReligionSettings.ts
@@ -9,7 +9,7 @@ import {
   ZiggurathUpgrade,
   ZiggurathUpgrades,
 } from "../types/index.js";
-import { Setting, SettingMax, SettingTrigger } from "./Settings.js";
+import { Setting, SettingMax, SettingThreshold, SettingTrigger } from "./Settings.js";
 
 export type FaithItem = Exclude<ReligionItem, UnicornItem>;
 
@@ -74,22 +74,22 @@ export class ReligionSettings extends SettingTrigger {
   /**
    * Sacrifice alicorns for time crystals.
    */
-  sacrificeAlicorns: SettingTrigger;
+  sacrificeAlicorns: SettingThreshold;
 
   /**
    * Sacrifice unicorns for tears.
    */
-  sacrificeUnicorns: SettingTrigger;
+  sacrificeUnicorns: SettingThreshold;
 
   /**
    * Refine tears into BLS.
    */
-  refineTears: SettingTrigger;
+  refineTears: SettingThreshold;
 
   /**
    * Refine time crystals into relics.
    */
-  refineTimeCrystals: SettingTrigger;
+  refineTimeCrystals: SettingThreshold;
 
   /**
    * Praise the sun.

--- a/packages/kitten-scientists/source/settings/ResetBonfireSettings.ts
+++ b/packages/kitten-scientists/source/settings/ResetBonfireSettings.ts
@@ -2,9 +2,9 @@ import { Maybe, isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import { consumeEntriesPedantic } from "../tools/Entries.js";
 import { Buildings, StagedBuildings } from "../types/index.js";
 import { BonfireItem } from "./BonfireSettings.js";
-import { Setting, SettingTrigger } from "./Settings.js";
+import { Setting, SettingThreshold } from "./Settings.js";
 
-export class ResetBonfireBuildingSetting extends SettingTrigger {
+export class ResetBonfireBuildingSetting extends SettingThreshold {
   readonly #building: BonfireItem;
 
   get building() {

--- a/packages/kitten-scientists/source/settings/ResetReligionSettings.ts
+++ b/packages/kitten-scientists/source/settings/ResetReligionSettings.ts
@@ -7,9 +7,9 @@ import {
   ZiggurathUpgrades,
 } from "../types/index.js";
 import { FaithItem, UnicornItem } from "./ReligionSettings.js";
-import { Setting, SettingTrigger } from "./Settings.js";
+import { Setting, SettingThreshold } from "./Settings.js";
 
-export class ResetReligionBuildingSetting extends SettingTrigger {
+export class ResetReligionBuildingSetting extends SettingThreshold {
   readonly #building: FaithItem | UnicornItem;
   readonly #variant: UnicornItemVariant;
 

--- a/packages/kitten-scientists/source/settings/ResetSpaceSettings.ts
+++ b/packages/kitten-scientists/source/settings/ResetSpaceSettings.ts
@@ -1,9 +1,9 @@
 import { Maybe, isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import { consumeEntriesPedantic } from "../tools/Entries.js";
 import { SpaceBuilding, SpaceBuildings } from "../types/index.js";
-import { Setting, SettingTrigger } from "./Settings.js";
+import { Setting, SettingThreshold } from "./Settings.js";
 
-export class ResetSpaceBuildingSetting extends SettingTrigger {
+export class ResetSpaceBuildingSetting extends SettingThreshold {
   readonly #building: SpaceBuilding;
 
   get building() {
@@ -16,7 +16,7 @@ export class ResetSpaceBuildingSetting extends SettingTrigger {
   }
 }
 
-export type ResetSpaceBuildingSettings = Record<SpaceBuilding, SettingTrigger>;
+export type ResetSpaceBuildingSettings = Record<SpaceBuilding, SettingThreshold>;
 
 export class ResetSpaceSettings extends Setting {
   readonly buildings: ResetSpaceBuildingSettings;

--- a/packages/kitten-scientists/source/settings/ResetTimeSettings.ts
+++ b/packages/kitten-scientists/source/settings/ResetTimeSettings.ts
@@ -1,10 +1,10 @@
 import { Maybe, isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import { consumeEntriesPedantic } from "../tools/Entries.js";
 import { ChronoForgeUpgrades, TimeItemVariant, VoidSpaceUpgrades } from "../types/index.js";
-import { Setting, SettingTrigger } from "./Settings.js";
+import { Setting, SettingThreshold } from "./Settings.js";
 import { TimeItem } from "./TimeSettings.js";
 
-export class ResetTimeBuildingSetting extends SettingTrigger {
+export class ResetTimeBuildingSetting extends SettingThreshold {
   readonly #building: TimeItem;
   readonly #variant: TimeItemVariant;
 

--- a/packages/kitten-scientists/source/settings/Settings.ts
+++ b/packages/kitten-scientists/source/settings/Settings.ts
@@ -49,6 +49,10 @@ export class SettingLimited extends Setting {
   }
 }
 
+/**
+ * A setting that also includes a trigger value.
+ * Trigger values range from 0 to 1. They reflect a percentage.
+ */
 export class SettingTrigger extends Setting {
   trigger: number;
 
@@ -58,6 +62,28 @@ export class SettingTrigger extends Setting {
   }
 
   load(setting: Maybe<Partial<SettingTrigger>>) {
+    if (isNil(setting)) {
+      return;
+    }
+
+    super.load(setting);
+    this.trigger = setting.trigger ?? this.trigger;
+  }
+}
+
+/**
+ * A setting that also includes an absolute value trigger.
+ * Trigger values range from 0 to Infinity, while -1 designates Infinity explicitly.
+ */
+export class SettingThreshold extends Setting {
+  trigger: number;
+
+  constructor(enabled = false, trigger = 1) {
+    super(enabled);
+    this.trigger = trigger;
+  }
+
+  load(setting: Maybe<Partial<SettingThreshold>>) {
     if (isNil(setting)) {
       return;
     }
@@ -184,7 +210,7 @@ export class SettingSell extends Setting {
   }
 }
 
-export class SettingBuySellTrigger extends SettingTrigger implements SettingBuy, SettingSell {
+export class SettingBuySellThreshold extends SettingThreshold implements SettingBuy, SettingSell {
   buy: number;
   sell: number;
 
@@ -194,7 +220,7 @@ export class SettingBuySellTrigger extends SettingTrigger implements SettingBuy,
     this.sell = sell;
   }
 
-  load(setting: Maybe<Partial<SettingBuySellTrigger>>) {
+  load(setting: Maybe<Partial<SettingBuySellThreshold>>) {
     if (isNil(setting)) {
       return;
     }

--- a/packages/kitten-scientists/source/settings/TradeSettings.ts
+++ b/packages/kitten-scientists/source/settings/TradeSettings.ts
@@ -5,7 +5,7 @@ import { EmbassySettings } from "./EmbassySettings.js";
 import {
   Requirement,
   Setting,
-  SettingBuySellTrigger,
+  SettingBuySellThreshold,
   SettingLimited,
   SettingTrigger,
 } from "./Settings.js";
@@ -55,7 +55,7 @@ export class TradeSettings extends SettingTrigger {
 
   feedLeviathans: Setting;
   buildEmbassies: EmbassySettings;
-  tradeBlackcoin: SettingBuySellTrigger;
+  tradeBlackcoin: SettingBuySellThreshold;
   unlockRaces: Setting;
 
   constructor(
@@ -63,7 +63,7 @@ export class TradeSettings extends SettingTrigger {
     trigger = 1,
     buildEmbassies = new EmbassySettings(),
     feedLeviathans = new Setting(false),
-    tradeBlackcoin = new SettingBuySellTrigger(false, 1090.0, 1095.0, 10000),
+    tradeBlackcoin = new SettingBuySellThreshold(false, 1090.0, 1095.0, 10000),
     unlockRaces = new Setting(true),
   ) {
     super(enabled, trigger);

--- a/packages/kitten-scientists/source/ui/ReligionSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/ReligionSettingsUi.ts
@@ -146,7 +146,6 @@ export class ReligionSettingsUi extends SettingsSectionUi<ReligionSettings> {
             });
           }
           return new SettingTriggerListItem(this._host, label, this.setting[item], {
-            behavior: "integer",
             onCheck: () => {
               this._host.engine.imessage("status.sub.enable", [label]);
             },

--- a/packages/kitten-scientists/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/TimeSkipHeatSettingsUi.ts
@@ -16,7 +16,7 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> 
     const label = host.engine.i18n("option.time.activeHeatTransfer");
     super(host, label, settings, options);
 
-    this._trigger = new TriggerButton(host, label, settings, "percentage");
+    this._trigger = new TriggerButton(host, label, settings);
     this._trigger.element.insertAfter(this._expando.element);
     this.children.add(this._trigger);
 

--- a/packages/kitten-scientists/source/ui/TimeSkipSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/TimeSkipSettingsUi.ts
@@ -29,7 +29,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings> {
     const label = host.engine.i18n("option.time.skip");
     super(host, label, settings, options);
 
-    this._trigger = new TriggerButton(host, label, settings, "integer");
+    this._trigger = new TriggerButton(host, label, settings);
     this._trigger.element.insertAfter(this._expando.element);
     this.children.add(this._trigger);
 

--- a/packages/kitten-scientists/source/ui/TradeSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/TradeSettingsUi.ts
@@ -66,7 +66,6 @@ export class TradeSettingsUi extends SettingsSectionUi<TradeSettings> {
       this._host.engine.i18n("option.crypto"),
       this.setting.tradeBlackcoin,
       {
-        behavior: "integer",
         delimiter: true,
         onCheck: () => {
           this._host.engine.imessage("status.sub.enable", [

--- a/packages/kitten-scientists/source/ui/components/SettingBuySellTriggerListItem.ts
+++ b/packages/kitten-scientists/source/ui/components/SettingBuySellTriggerListItem.ts
@@ -1,13 +1,9 @@
 import { KittenScientists } from "../../KittenScientists.js";
-import { SettingBuySellTrigger } from "../../settings/Settings.js";
-import { TriggerButton, TriggerButtonBehavior } from "./buttons-icon/TriggerButton.js";
+import { SettingBuySellThreshold } from "../../settings/Settings.js";
+import { TriggerButton } from "./buttons-icon/TriggerButton.js";
 import { BuyButton } from "./buttons-text/BuyButton.js";
 import { SellButton } from "./buttons-text/SellButton.js";
 import { SettingListItem, SettingListItemOptions } from "./SettingListItem.js";
-
-export type SettingBuySellTriggerListItemOptions = SettingListItemOptions & {
-  behavior: TriggerButtonBehavior;
-};
 
 export class SettingBuySellTriggerListItem extends SettingListItem {
   readonly buyButton: BuyButton;
@@ -17,13 +13,13 @@ export class SettingBuySellTriggerListItem extends SettingListItem {
   constructor(
     host: KittenScientists,
     label: string,
-    setting: SettingBuySellTrigger,
-    options?: Partial<SettingBuySellTriggerListItemOptions>,
+    setting: SettingBuySellThreshold,
+    options?: Partial<SettingListItemOptions>,
   ) {
     super(host, label, setting, options);
 
     const triggerLabel = host.engine.i18n("blackcoin.buy.trigger");
-    this.triggerButton = new TriggerButton(host, triggerLabel, setting, options?.behavior);
+    this.triggerButton = new TriggerButton(host, triggerLabel, setting);
     this.element.append(this.triggerButton.element);
 
     this.sellButton = new SellButton(host, label, setting);

--- a/packages/kitten-scientists/source/ui/components/SettingTriggerListItem.ts
+++ b/packages/kitten-scientists/source/ui/components/SettingTriggerListItem.ts
@@ -18,7 +18,7 @@ export class SettingTriggerListItem extends SettingListItem {
   ) {
     super(host, label, setting, options);
 
-    this.triggerButton = new TriggerButton(host, label, setting, options?.behavior);
+    this.triggerButton = new TriggerButton(host, label, setting);
     this.element.append(this.triggerButton.element);
   }
 

--- a/packages/kitten-scientists/source/ui/components/buttons-icon/TriggerButton.ts
+++ b/packages/kitten-scientists/source/ui/components/buttons-icon/TriggerButton.ts
@@ -1,6 +1,6 @@
 import { Icons } from "../../../images/Icons.js";
 import { KittenScientists } from "../../../KittenScientists.js";
-import { SettingTrigger } from "../../../settings/Settings.js";
+import { SettingThreshold, SettingTrigger } from "../../../settings/Settings.js";
 import { SettingsSectionUi } from "../../SettingsSectionUi.js";
 import { IconButton } from "../IconButton.js";
 
@@ -8,22 +8,21 @@ export type TriggerButtonBehavior = "integer" | "percentage";
 
 export class TriggerButton extends IconButton {
   readonly behavior: TriggerButtonBehavior;
-  readonly setting: SettingTrigger;
+  readonly setting: SettingTrigger | SettingThreshold;
 
   constructor(
     host: KittenScientists,
     label: string,
-    setting: SettingTrigger,
-    behavior: TriggerButtonBehavior = "percentage",
+    setting: SettingTrigger | SettingThreshold,
     handler: { onClick?: () => void } = {},
   ) {
     super(host, Icons.Trigger, "");
 
-    this.behavior = behavior;
+    this.behavior = setting instanceof SettingTrigger ? "percentage" : "integer";
 
     this.element.on("click", () => {
       const value =
-        this.behavior === "percentage"
+        this.setting instanceof SettingTrigger
           ? SettingsSectionUi.promptPercentage(
               host.engine.i18n("ui.trigger.setpercentage", [label]),
               SettingsSectionUi.renderPercentage(setting.trigger),


### PR DESCRIPTION
Some of our triggers are expressed as percentage, some as an absolute value. Developers always had to carefully the correct handler for the given kind of trigger. This was cumbersome and error-prone.

We now introduce a new data structure to handle this kinds of triggers more intuitively and without explicit selection.

Fixes #627