### PR TITLE
feat(time): Remove Chrono Furnace automation

### DIFF
--- a/packages/kitten-scientists/source/TimeManager.ts
+++ b/packages/kitten-scientists/source/TimeManager.ts
@@ -52,9 +52,6 @@ export class TimeManager {
     if (this.settings.fixCryochambers.enabled) {
       this.fixCryochambers();
     }
-    if (this.settings.turnOnChronoFurnace.enabled) {
-      this.turnOnChronoFurnace();
-    }
   }
 
   /**
@@ -198,17 +195,6 @@ export class TimeManager {
     if (0 < fixed) {
       this._host.engine.iactivity("act.fix.cry", [fixed], "ks-fixCry");
       this._host.engine.storeForSummary("fix.cry", fixed);
-    }
-  }
-
-  turnOnChronoFurnace() {
-    const chronoFurnace = this._host.game.time.getCFU("blastFurnace");
-    if (!mustExist(chronoFurnace.isAutomationEnabled)) {
-      const button = this.getBuildButton("blastFurnace", TimeItemVariant.Chronoforge);
-      if (isNil(button?.model)) {
-        return;
-      }
-      button.controller.handleToggleAutomationLinkClick(button.model);
     }
   }
 }

--- a/packages/kitten-scientists/source/i18n/en-US.json
+++ b/packages/kitten-scientists/source/i18n/en-US.json
@@ -62,7 +62,6 @@
   "option.accelerate": "Tempus Fugit",
   "option.autofeed": "Feed Leviathans",
   "option.catnip": "Gather Catnip",
-  "option.chronofurnace": "Turn on Chrono Furnaces",
   "option.crypto": "Trade Blackcoin",
   "option.elect.job.any": "Any",
   "option.elect.job": "Job",

--- a/packages/kitten-scientists/source/settings/TimeSettings.ts
+++ b/packages/kitten-scientists/source/settings/TimeSettings.ts
@@ -38,18 +38,11 @@ export class TimeSettings extends SettingTrigger {
   buildings: TimeBuildingsSettings;
 
   fixCryochambers: Setting;
-  turnOnChronoFurnace: Setting;
 
-  constructor(
-    enabled = false,
-    trigger = -1,
-    fixCryochambers = new Setting(false),
-    turnOnChronoFurnace = new Setting(false),
-  ) {
+  constructor(enabled = false, trigger = -1, fixCryochambers = new Setting(false)) {
     super(enabled, trigger);
     this.buildings = this.initBuildings();
     this.fixCryochambers = fixCryochambers;
-    this.turnOnChronoFurnace = turnOnChronoFurnace;
   }
 
   private initBuildings(): TimeBuildingsSettings {
@@ -78,6 +71,5 @@ export class TimeSettings extends SettingTrigger {
     });
 
     this.fixCryochambers.load(settings.fixCryochambers);
-    this.turnOnChronoFurnace.load(settings.turnOnChronoFurnace);
   }
 }

--- a/packages/kitten-scientists/source/ui/TimeSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/TimeSettingsUi.ts
@@ -119,23 +119,6 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings> {
               },
             },
           ),
-          new SettingListItem(
-            this._host,
-            this._host.engine.i18n("option.chronofurnace"),
-            this.setting.turnOnChronoFurnace,
-            {
-              onCheck: () => {
-                this._host.engine.imessage("status.sub.enable", [
-                  this._host.engine.i18n("option.chronofurnace"),
-                ]);
-              },
-              onUnCheck: () => {
-                this._host.engine.imessage("status.sub.disable", [
-                  this._host.engine.i18n("option.chronofurnace"),
-                ]);
-              },
-            },
-          ),
         ],
         hasDisableAll: false,
         hasEnableAll: false,


### PR DESCRIPTION
Always turning on Chrono Furnaces is counter-productive in most scenarios. This is superseded by better automations in the Time Control section.