### PR TITLE
feat(ui): Indicate when Active Heat Transfer is active

### DIFF
--- a/packages/kitten-scientists/source/TimeControlManager.ts
+++ b/packages/kitten-scientists/source/TimeControlManager.ts
@@ -453,6 +453,7 @@ export class TimeControlManager {
         // Heat Transfer to specified value
         if (heatNow <= heatMax * this.settings.timeSkip.activeHeatTransfer.trigger) {
           this.settings.timeSkip.activeHeatTransfer.activeHeatTransferStatus.enabled = false;
+          this._host.refreshUi();
           this._host.engine.iactivity("act.time.activeHeatTransferEnd", [], "ks-timeSkip");
         }
         // Get temporalFlux
@@ -491,6 +492,7 @@ export class TimeControlManager {
         }
       } else if (heatNow >= heatMax - heatPerTick * ticksPerSecond * 10) {
         this.settings.timeSkip.activeHeatTransfer.activeHeatTransferStatus.enabled = true;
+        this._host.refreshUi();
         this._host.engine.iactivity("act.time.activeHeatTransferStart", [], "ks-timeSkip");
         this._host.engine.storeForSummary("time.activeHeatTransferStart", 1);
       }

--- a/packages/kitten-scientists/source/ui/TimeSkipHeatSettingsUi.module.css
+++ b/packages/kitten-scientists/source/ui/TimeSkipHeatSettingsUi.module.css
@@ -1,0 +1,42 @@
+@keyframes scale {
+  0% {
+    scale: 0.5;
+    opacity: 0;
+  }
+  50% {
+    scale: 1;
+    opacity: 1;
+  }
+  100% {
+    scale: 2;
+    opacity: 0;
+  }
+}
+
+.active {
+  text-shadow: rgba(128, 128, 128, 0.8) 0 0 15px;
+  position: relative;
+
+  &::after,
+  &::before {
+    display: inline-block;
+    width: 1em;
+    height: 100%;
+    position: absolute;
+    right: -1.5em;
+    scale: 0;
+    text-align: center;
+    transform-origin: center;
+  }
+
+  &::after {
+    content: attr(data-ks-active-from);
+    animation: scale 8s linear infinite;
+  }
+
+  &::before {
+    content: attr(data-ks-active-to);
+    animation: scale 8s linear infinite;
+    animation-delay: 4s;
+  }
+}

--- a/packages/kitten-scientists/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/packages/kitten-scientists/source/ui/TimeSkipHeatSettingsUi.ts
@@ -6,9 +6,10 @@ import { TimeSkipHeatSettings } from "../settings/TimeSkipHeatSettings.js";
 import { PanelOptions } from "./components/CollapsiblePanel.js";
 import { CyclesList } from "./components/CyclesList.js";
 import { Dialog } from "./components/Dialog.js";
-import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
+import styles from "./TimeSkipHeatSettingsUi.module.css";
 
 export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> {
   constructor(
@@ -27,9 +28,22 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> 
         },
         onUnCheck: () => {
           host.engine.imessage("status.auto.disable", [label]);
+          settings.activeHeatTransferStatus.enabled = false;
         },
         onRefresh: item => {
           (item as SettingTriggerListItem).triggerButton.inactive = !settings.enabled;
+          (item as SettingTriggerListItem).triggerButton.ineffective =
+            settings.enabled && settings.trigger === -1;
+          this.expando.ineffective =
+            settings.enabled && !Object.values(settings.cycles).some(cycle => cycle.enabled);
+
+          if (settings.activeHeatTransferStatus.enabled) {
+            this.head.elementLabel.attr("data-ks-active-from", "◎");
+            this.head.elementLabel.attr("data-ks-active-to", "◎");
+            this.head.elementLabel.addClass(styles.active);
+          } else {
+            this.head.elementLabel.removeClass(styles.active);
+          }
         },
         onSetTrigger: () => {
           Dialog.prompt(

--- a/packages/kitten-scientists/source/ui/UserInterface.module.css
+++ b/packages/kitten-scientists/source/ui/UserInterface.module.css
@@ -39,31 +39,33 @@
     opacity: 1;
   }
 }
+
 .spacer {
   display: block;
   margin-bottom: 100px;
 }
+
 .ui {
   margin: 5px 0 10px 0;
   padding-right: 10px;
-}
-.ui ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Rules needed to enable stock warning. */
+  #toggle-list-resources .stockWarn *,
+  #toggle-reset-list-resources .stockWarn * {
+    color: #dd1e00;
+  }
 }
 
 .showActivity {
   cursor: pointer;
   display: inline-block;
   vertical-align: middle;
-}
-
-/* Rules needed to enable stock warning. */
-
-.ui #toggle-list-resources .stockWarn *,
-.ui #toggle-reset-list-resources .stockWarn * {
-  color: #dd1e00;
 }
 
 /* Ensure the right column gets a scrollbar, when our content extends it too far down. */


### PR DESCRIPTION
When Active Heat Transfer is currently actively transferring heat, you will now see an animated indicator next to it.

In case this is unclear, Active Heat Transfer prevents time skips during this period, until all the chrono heat has been transferred into furnaces.

![image](https://github.com/user-attachments/assets/14c80749-914f-49a2-a9fa-6d9ba46a3ca3)
