### PR TITLE
fix: Regressions introduced from recent game update

### DIFF
--- a/source/BonfireManager.ts
+++ b/source/BonfireManager.ts
@@ -386,10 +386,7 @@ export class BonfireManager implements Automation {
     const buttons = this.manager.tab.children;
     const build = this.getBuild(name);
     const label = this._getBuildLabel(build.meta, stage);
-    return (buttons.find(button => button.model?.name.startsWith(label)) ?? null) as BuildButton<
-      string,
-      ButtonModernModel,
-      ButtonModernController
-    > | null;
+    return (buttons.find(button => (button.model?.options.name as string).startsWith(label)) ??
+      null) as BuildButton<string, ButtonModernModel, ButtonModernController> | null;
   }
 }

--- a/source/BonfireManager.ts
+++ b/source/BonfireManager.ts
@@ -333,9 +333,7 @@ export class BonfireManager implements Automation {
   autoGather(): void {
     const controller = new classes.game.ui.GatherCatnipButtonController(this._host.game);
     for (let clicks = 0; clicks < Math.floor(this._host.engine.settings.interval / 20); ++clicks) {
-      controller.buyItem(null, null, () => {
-        /* intentionally left blank */
-      });
+      controller.buyItem(null, null);
     }
   }
 

--- a/source/ReligionManager.ts
+++ b/source/ReligionManager.ts
@@ -516,13 +516,11 @@ export class ReligionManager implements Automation {
       return null;
     }
 
-    const build = this.getBuild(name, variant);
-    if (build === null) {
-      throw new Error(`Unable to retrieve build information for '${name}'`);
-    }
-
-    return (buttons.find(button => button.model?.name.startsWith(build.label)) ??
-      null) as BuildButton<string, ButtonModernModel, ButtonModernController> | null;
+    return (buttons.find(button => button.id === name) ?? null) as BuildButton<
+      string,
+      ButtonModernModel,
+      ButtonModernController
+    > | null;
   }
 
   private _transformBtnSacrificeHelper(

--- a/source/ReligionManager.ts
+++ b/source/ReligionManager.ts
@@ -73,7 +73,7 @@ export class ReligionManager implements Automation {
     }
 
     if (this.settings.refineTears.enabled) {
-      await this._autoTears(context);
+      this._autoTears(context);
     }
 
     if (this.settings.refineTimeCrystals.enabled) {
@@ -611,7 +611,7 @@ export class ReligionManager implements Automation {
     }
   }
 
-  private async _autoTears(context: FrameContext) {
+  private _autoTears(context: FrameContext) {
     const tears = this._workshopManager.getResource("tears");
     const available = this._workshopManager.getValueAvailable("tears");
     const sorrow = this._workshopManager.getResource("sorrow");
@@ -635,9 +635,7 @@ export class ReligionManager implements Automation {
         return;
       }
 
-      await new Promise(resolve => {
-        controller.buyItem(model, new Event("decoy"), resolve, availableForConversion);
-      });
+      controller.buyItem(model, new Event("decoy"), availableForConversion);
 
       const availableNow = this._workshopManager.getValueAvailable("tears");
       const cost = available - availableNow;

--- a/source/TimeManager.ts
+++ b/source/TimeManager.ts
@@ -10,6 +10,7 @@ import {
   type BuildButton,
   type ButtonModernController,
   type ButtonModernModel,
+  type BuyResultOperation,
   type ChronoForgeUpgrade,
   type ChronoForgeUpgradeInfo,
   type FixCryochamberBtnController,
@@ -18,6 +19,7 @@ import {
   type VoidSpaceUpgrade,
   type VoidSpaceUpgradeInfo,
 } from "./types/index.js";
+import { BuyButton } from "./ui/components/buttons-text/BuyButton.js";
 
 export class TimeManager {
   private readonly _host: KittenScientists;
@@ -183,16 +185,21 @@ export class TimeManager {
     do {
       fixHappened = false;
 
-      (btn.controller as FixCryochamberBtnController).buyItem(
+      const buyResult = (btn.controller as FixCryochamberBtnController).buyItem(
         btn.model as ButtonModernModel,
         new MouseEvent("click"),
+      );
+
+      if (buyResult.def !== undefined) {
         // This callback is invoked at the end of the `buyItem` call.
         // Thus, the callback should be invoked before this loop ends.
-        (didHappen: boolean) => {
-          fixHappened = didHappen;
+        buyResult.def.then((didHappen: BuyResultOperation) => {
+          fixHappened = didHappen.itemBought;
           fixed += didHappen ? 1 : 0;
-        },
-      );
+        })
+      } else {
+        fixHappened = buyResult.itemBought;
+      }
     } while (fixHappened);
 
     if (0 < fixed) {

--- a/source/TimeManager.ts
+++ b/source/TimeManager.ts
@@ -156,13 +156,11 @@ export class TimeManager {
       buttons = this.manager.tab.children[3].children[0].children;
     }
 
-    const build = this.getBuild(name, variant);
-    if (isNil(build)) {
-      throw new Error(`Unable to retrieve build information for '${name}'`);
-    }
-
-    return (buttons.find(button => button.model?.name.startsWith(build.label)) ??
-      null) as BuildButton<string, ButtonModernModel, ButtonModernController> | null;
+    return (buttons.find(button => button.id === name) ?? null) as BuildButton<
+      string,
+      ButtonModernModel,
+      ButtonModernController
+    > | null;
   }
 
   fixCryochambers() {

--- a/source/TimeManager.ts
+++ b/source/TimeManager.ts
@@ -196,7 +196,7 @@ export class TimeManager {
         buyResult.def.then((didHappen: BuyResultOperation) => {
           fixHappened = didHappen.itemBought;
           fixed += didHappen ? 1 : 0;
-        })
+        });
       } else {
         fixHappened = buyResult.itemBought;
       }

--- a/source/UpgradeManager.ts
+++ b/source/UpgradeManager.ts
@@ -1,7 +1,14 @@
 import type { KittenScientists } from "./KittenScientists.js";
 import type { TabManager } from "./TabManager.js";
 import { cwarn } from "./tools/Log.js";
-import type { BuildButton, Policy, ScienceTab, Technology, Upgrade, UpgradeInfo } from "./types/index.js";
+import type {
+  BuildButton,
+  Policy,
+  ScienceTab,
+  Technology,
+  Upgrade,
+  UpgradeInfo,
+} from "./types/index.js";
 
 export abstract class UpgradeManager {
   protected readonly _host: KittenScientists;

--- a/source/UpgradeManager.ts
+++ b/source/UpgradeManager.ts
@@ -12,7 +12,7 @@ export abstract class UpgradeManager {
   }
 
   async upgrade(
-    upgrade: { label: string },
+    upgrade: { label: string; name: string },
     variant: "policy" | "science" | "workshop",
   ): Promise<boolean> {
     const button = this._getUpgradeButton(upgrade, variant);
@@ -36,7 +36,13 @@ export abstract class UpgradeManager {
     const success = await UpgradeManager.skipConfirm(
       () =>
         new Promise(resolve => {
-          controller.buyItem(button.model, new MouseEvent("click"), resolve);
+          const buyResult = controller.buyItem(button.model, new MouseEvent("click"));
+
+          if (buyResult.def !== undefined) {
+            buyResult.def.then(resolve);
+          } else {
+            resolve(buyResult.itemBought);
+          }
         }),
     );
 
@@ -78,7 +84,7 @@ export abstract class UpgradeManager {
   }
 
   private _getUpgradeButton(
-    upgrade: { label: string },
+    upgrade: { name: string },
     variant: "policy" | "science" | "workshop",
   ): BuildButton | null {
     let buttons: Array<BuildButton> | undefined;
@@ -91,7 +97,6 @@ export abstract class UpgradeManager {
       buttons = this.manager.tab.buttons;
     }
 
-    return (buttons?.find(button => button.model?.name === upgrade.label) ??
-      null) as BuildButton | null;
+    return (buttons?.find(button => button.id === upgrade.name) ?? null) as BuildButton | null;
   }
 }

--- a/source/UpgradeManager.ts
+++ b/source/UpgradeManager.ts
@@ -1,7 +1,7 @@
 import type { KittenScientists } from "./KittenScientists.js";
 import type { TabManager } from "./TabManager.js";
 import { cwarn } from "./tools/Log.js";
-import type { BuildButton, ScienceTab } from "./types/index.js";
+import type { BuildButton, Policy, ScienceTab, Technology, Upgrade, UpgradeInfo } from "./types/index.js";
 
 export abstract class UpgradeManager {
   protected readonly _host: KittenScientists;
@@ -12,7 +12,7 @@ export abstract class UpgradeManager {
   }
 
   async upgrade(
-    upgrade: { label: string; name: string },
+    upgrade: { label: string; name: Policy | Upgrade | Technology },
     variant: "policy" | "science" | "workshop",
   ): Promise<boolean> {
     const button = this._getUpgradeButton(upgrade, variant);
@@ -84,7 +84,7 @@ export abstract class UpgradeManager {
   }
 
   private _getUpgradeButton(
-    upgrade: { name: string },
+    upgrade: { name: Policy | Upgrade | Technology },
     variant: "policy" | "science" | "workshop",
   ): BuildButton | null {
     let buttons: Array<BuildButton> | undefined;

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -306,12 +306,21 @@ export type ButtonController = {
   rejustPrice: (model: ButtonModel, ratio: number) => void;
   payPrice: (model: ButtonModel) => void;
   clickHandler: (model: ButtonModel, event: Event) => void;
-  buyItem: (
-    model: ButtonModel | null,
-    event: Event | null,
-    callback: (success: boolean) => void,
-  ) => void;
+  buyItem: (model: ButtonModel | null, event: Event | null) => DefferrableBuyResultOperation;
   refund: (model: ButtonModel) => void;
+};
+
+export type BuyResultOperation = {
+  itemBought: boolean;
+  reason: string;
+};
+
+export type DefferrableBuyResultOperation = {
+  itemBought: boolean;
+  reason: string;
+  def?: {
+    then: (callable: (result: BuyResultOperation) => void) => void;
+  };
 };
 
 export type ButtonModernModel = {
@@ -356,7 +365,7 @@ export type BuildingNotStackableBtnController = BuildingBtnController & {
 
 export type BuildingStackableBtnController = BuildingBtnController & {
   new (game: Game): BuildingStackableBtnController;
-  _buyItem_step2: (model: ButtonModel, event: Event, callback: (success: boolean) => void) => void;
+  _buyItem_step2: (model: ButtonModel, event: Event) => DefferrableBuyResultOperation;
   build: (model: ButtonModel, maxBld: number) => void;
   incrementValue: (model: ButtonModel) => void;
 };
@@ -382,12 +391,7 @@ export type PolicyBtnController = BuildingNotStackableBtnController & {
 export type RefineTearsBtnController = ButtonModernController & {
   new (game: Game): ButtonModernController;
   _newLink: (model: ButtonModel, divider: number) => Link;
-  buyItem: (
-    model: ButtonModel | null,
-    event: Event | null,
-    callback: (success: boolean) => void,
-    count: number,
-  ) => void;
+  buyItem: (model: ButtonModel | null, event: Event | null, count: number) => BuyResultOperation;
   refine: () => void;
 };
 


### PR DESCRIPTION
Recently KG merged in KGM which added HTML to the `button.model.name` fields. For the `time` and `religion` tab it appears using the `id` field directly will be more stable to these types of changes. For the `bonfire` tab the `id`s are not set in the game data, but the `button.model.options.name` seems to not contain HTML and matches what we expect.

Tested locally and as a userscript against the main site, but this is my first contribution so highly recommend extra scrutiny.

Fixes #947 