### PR TITLE
fix: Makefile compatibility with Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ output: node_modules
 .PHONY: injectable
 injectable: node_modules
 	yarn vite --config vite.config.inject.js build
-	mkdir --parents devcontainer/overlay/ && cp output/kitten-scientists.inject.js devcontainer/overlay/kitten-scientists.inject.js
+	mkdir -p devcontainer/overlay/ && cp output/kitten-scientists.inject.js devcontainer/overlay/kitten-scientists.inject.js
 
 .PHONY: userscript
 userscript: node_modules


### PR DESCRIPTION
Changed mkdir --parents option to mkdir -p

Fixes #953 