### PR TITLE
Clean up GUI solution code

### DIFF
--- a/source/KittenScientists.ts
+++ b/source/KittenScientists.ts
@@ -75,7 +75,6 @@ export class KittenScientists {
   private _constructUi() {
     const ui = new UserInterface(this);
     ui.stateManagementUi.loadAutoSave();
-    ui.refreshUi();
     return ui;
   }
 
@@ -210,8 +209,8 @@ export class KittenScientists {
   /**
    * Requests the user interface to refresh.
    */
-  refreshUi() {
-    this._userInterface.refreshUi();
+  refreshUi(): void {
+    this._userInterface.requestRefresh();
   }
 
   /**
@@ -360,7 +359,7 @@ export class KittenScientists {
     if (settings.engine.ksColumn.enabled) {
       this.rebuildUi();
     } else {
-      this._userInterface.refreshUi();
+      this._userInterface.refresh(true);
     }
   }
 

--- a/source/KittenScientists.ts
+++ b/source/KittenScientists.ts
@@ -126,7 +126,7 @@ export class KittenScientists {
     // TODO: This should be configurable.
     this.game.console.maxMessages = 1000;
 
-    this.refreshUi();
+    this.refreshEntireUserInterface();
 
     if (this.engine.settings.enabled) {
       this.engine.start(true);
@@ -209,8 +209,9 @@ export class KittenScientists {
   /**
    * Requests the user interface to refresh.
    */
-  refreshUi(): void {
-    this._userInterface.requestRefresh();
+  refreshEntireUserInterface(): void {
+    console.info(...cl("Requesting entire user interface to be refreshed."));
+    this._userInterface.forceFullRefresh();
   }
 
   /**
@@ -425,7 +426,7 @@ export class KittenScientists {
 
       console.info(...cl("Found Kitten Scientists engine state in save data."));
       this.engine.stateLoad(state);
-      this.refreshUi();
+      this.refreshEntireUserInterface();
     },
     resetState: () => null,
     save: (_saveData: Record<string, unknown>) => {

--- a/source/ReligionManager.ts
+++ b/source/ReligionManager.ts
@@ -122,7 +122,7 @@ export class ReligionManager implements Automation {
     const bestUnicornBuilding = this.getBestUnicornBuilding();
     if (this.settings.bestUnicornBuildingCurrent !== bestUnicornBuilding) {
       this.settings.bestUnicornBuildingCurrent = bestUnicornBuilding;
-      this._host.refreshUi();
+      this._host.refreshEntireUserInterface();
     }
 
     if (this.settings.bestUnicornBuildingCurrent === null) {

--- a/source/TimeControlManager.ts
+++ b/source/TimeControlManager.ts
@@ -437,7 +437,7 @@ export class TimeControlManager {
         // Heat Transfer to specified value
         if (heatNow <= heatMax * this.settings.timeSkip.activeHeatTransfer.trigger) {
           this.settings.timeSkip.activeHeatTransfer.activeHeatTransferStatus.enabled = false;
-          this._host.refreshUi();
+          this._host.refreshEntireUserInterface();
           this._host.engine.iactivity("act.time.activeHeatTransferEnd", [], "ks-timeSkip");
         }
         // Get temporalFlux
@@ -476,7 +476,7 @@ export class TimeControlManager {
         }
       } else if (heatNow >= heatMax - heatPerTick * ticksPerSecond * 10) {
         this.settings.timeSkip.activeHeatTransfer.activeHeatTransferStatus.enabled = true;
-        this._host.refreshUi();
+        this._host.refreshEntireUserInterface();
         this._host.engine.iactivity("act.time.activeHeatTransferStart", [], "ks-timeSkip");
         this._host.engine.storeForSummary("time.activeHeatTransferStart", 1);
       }

--- a/source/TradeManager.ts
+++ b/source/TradeManager.ts
@@ -364,9 +364,7 @@ export class TradeManager implements Automation {
       }
       cultureVal = this._workshopManager.getValueAvailable("culture");
       if (cultureVal < emBulk.priceSum) {
-        console.warn(
-          ...cl<string | number>("Something has gone horribly wrong.", emBulk.priceSum, cultureVal),
-        );
+        console.warn(...cl("Something has gone horribly wrong.", emBulk.priceSum, cultureVal));
       }
       // We don't want to invoke the embassy build action multiple times, as
       // that would cause lots of log messages.

--- a/source/tools/Log.ts
+++ b/source/tools/Log.ts
@@ -1,4 +1,4 @@
 export const cl = <T extends Array<unknown>>(...args: T): Array<string | T[number]> => [
   "👩‍🔬",
-  ...args,
+  ...args.filter(arg => arg !== ""),
 ];

--- a/source/tools/Log.ts
+++ b/source/tools/Log.ts
@@ -1,1 +1,4 @@
-export const cl = <T>(...args: Array<T>): Array<string | T> => ["👩‍🔬", ...args];
+export const cl = <T extends Array<unknown>>(...args: T): Array<string | T[number]> => [
+  "👩‍🔬",
+  ...args,
+];

--- a/source/ui/BonfireSettingsUi.ts
+++ b/source/ui/BonfireSettingsUi.ts
@@ -1,5 +1,4 @@
 import { coalesceArray, isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { BonfireSettings } from "../settings/BonfireSettings.js";
@@ -38,7 +37,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
+        onRefresh: () => {
           const element = this.settingItem;
           element.triggerButton.inactive = !settings.enabled || settings.trigger < 0;
           element.triggerButton.ineffective =
@@ -57,7 +56,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
             !settings.turnOnSteamworks.enabled &&
             !settings.upgradeBuildings.enabled;
         },
-        onRefreshTrigger: item => {
+        onRefreshTrigger: () => {
           const element = this.settingItem;
           element.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
@@ -65,8 +64,8 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -77,23 +76,18 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
         },
       }),
     );

--- a/source/ui/BonfireSettingsUi.ts
+++ b/source/ui/BonfireSettingsUi.ts
@@ -84,6 +84,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -206,6 +207,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
           settings,
           meta.stages[0].label,
           sectionLabel,
+          { renderLabelTrigger: false },
         ),
         BuildSectionTools.getBuildOption(
           parent,
@@ -215,6 +217,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
           meta.stages[1].label,
           sectionLabel,
           {
+            renderLabelTrigger: false,
             upgradeIndicator: true,
           },
         ),
@@ -229,6 +232,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
           settings,
           meta.label,
           sectionLabel,
+          { renderLabelTrigger: false },
         ),
       ];
     }

--- a/source/ui/BonfireSettingsUi.ts
+++ b/source/ui/BonfireSettingsUi.ts
@@ -16,7 +16,7 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class BonfireSettingsUi extends SettingsPanel<BonfireSettings> {
+export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: BonfireSettings,
@@ -39,8 +39,7 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings> {
           options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: item => {
-          const element = item as SettingTriggerListItem;
-
+          const element = this.settingItem;
           element.triggerButton.inactive = !settings.enabled || settings.trigger < 0;
           element.triggerButton.ineffective =
             settings.enabled &&
@@ -59,7 +58,8 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings> {
             !settings.upgradeBuildings.enabled;
         },
         onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+          const element = this.settingItem;
+          element.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/BonfireSettingsUi.ts
+++ b/source/ui/BonfireSettingsUi.ts
@@ -90,11 +90,11 @@ export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTri
     // Post-super() child insertion, so we can use this._getBuildOptions().
     // We want the ability to use `this` in our callbacks, to construct more complex
     // usage scenarios where we need access to the entire UI section.
-    this.addChildren([
+    this.addChildrenContent([
       new SettingsList(this, {
         onReset: () => {
           this.setting.load({ buildings: new BonfireSettings().buildings });
-          this.refreshUi();
+          this.requestRefresh();
         },
       }).addChildren(
         coalesceArray(

--- a/source/ui/BonfireSettingsUi.ts
+++ b/source/ui/BonfireSettingsUi.ts
@@ -6,21 +6,20 @@ import type { SettingOptions } from "../settings/Settings.js";
 import type { Building, StagedBuilding } from "../types/index.js";
 import { BuildSectionTools } from "./BuildSectionTools.js";
 import { BuildingUpgradeSettingsUi } from "./BuildingUpgradeSettingsUi.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Delimiter } from "./components/Delimiter.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class BonfireSettingsUi extends SettingsPanel<BonfireSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: BonfireSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.build");
     super(

--- a/source/ui/BuildSectionTools.ts
+++ b/source/ui/BuildSectionTools.ts
@@ -9,16 +9,14 @@ import {
 } from "./components/SettingMaxTriggerListItem.js";
 
 export const BuildSectionTools = {
-  getBuildOption: <
-    TOptions extends SettingMaxTriggerListItemOptions = SettingMaxTriggerListItemOptions,
-  >(
+  getBuildOption: (
     host: KittenScientists,
     option: SettingTriggerMax,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: SettingTrigger,
     label: string,
     sectionLabel: string,
-    options?: Partial<TOptions>,
+    options?: Partial<SettingMaxTriggerListItemOptions>,
   ) => {
     const onSetMax = () => {
       Dialog.prompt(

--- a/source/ui/BuildSectionTools.ts
+++ b/source/ui/BuildSectionTools.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions, SettingTrigger, SettingTriggerMax } from "../settings/Settings.js";
@@ -18,8 +17,8 @@ export const BuildSectionTools = {
     sectionLabel: string,
     options?: Partial<SettingMaxTriggerListItemOptions>,
   ) => {
-    const onSetMax = () => {
-      Dialog.prompt(
+    const onSetMax = async () => {
+      const value = await Dialog.prompt(
         host,
         host.engine.i18n("ui.max.prompt.absolute"),
         host.engine.i18n("ui.max.build.prompt", [
@@ -28,27 +27,22 @@ export const BuildSectionTools = {
         ]),
         host.renderAbsolute(option.max),
         host.engine.i18n("ui.max.build.promptExplainer"),
-      )
-        .then(value => {
-          if (value === undefined) {
-            return;
-          }
+      );
 
-          if (value === "" || value.startsWith("-")) {
-            option.max = -1;
-            return;
-          }
+      if (value === undefined) {
+        return;
+      }
 
-          if (value === "0") {
-            option.enabled = false;
-          }
+      if (value === "" || value.startsWith("-")) {
+        option.max = -1;
+        return;
+      }
 
-          option.max = host.parseAbsolute(value) ?? option.max;
-        })
-        .then(() => {
-          element.refreshUi();
-        })
-        .catch(redirectErrorsToConsole(console));
+      if (value === "0") {
+        option.enabled = false;
+      }
+
+      option.max = host.parseAbsolute(value) ?? option.max;
     };
 
     const element = new SettingMaxTriggerListItem(host, option, locale, label, {
@@ -94,8 +88,8 @@ export const BuildSectionTools = {
         ]);
       },
       onSetMax,
-      onSetTrigger: () => {
-        Dialog.prompt(
+      onSetTrigger: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.trigger.prompt.percentage"),
           host.engine.i18n("ui.trigger.build.prompt", [
@@ -106,23 +100,18 @@ export const BuildSectionTools = {
           ]),
           option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
           host.engine.i18n("ui.trigger.build.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              option.trigger = -1;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            option.trigger = host.parsePercentage(value);
-          })
-          .then(() => {
-            element.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          option.trigger = -1;
+          return;
+        }
+
+        option.trigger = host.parsePercentage(value);
       },
       upgradeIndicator: options?.upgradeIndicator,
     });

--- a/source/ui/BuildSectionTools.ts
+++ b/source/ui/BuildSectionTools.ts
@@ -116,6 +116,7 @@ export const BuildSectionTools = {
 
         option.trigger = parent.host.parsePercentage(value);
       },
+      renderLabelTrigger: options?.renderLabelTrigger,
       upgradeIndicator: options?.upgradeIndicator,
     });
     return element;

--- a/source/ui/BuildSectionTools.ts
+++ b/source/ui/BuildSectionTools.ts
@@ -47,10 +47,10 @@ export const BuildSectionTools = {
 
     const element = new SettingMaxTriggerListItem(parent, option, locale, label, {
       delimiter: options?.delimiter,
-      onCheck: (isBatchProcess?: boolean) => {
+      onCheck: async (isBatchProcess?: boolean) => {
         parent.host.engine.imessage("status.sub.enable", [label]);
         if (option.max === 0 && !isBatchProcess) {
-          onSetMax();
+          await onSetMax();
         }
         options?.onCheck?.(isBatchProcess);
       },

--- a/source/ui/BuildSectionTools.ts
+++ b/source/ui/BuildSectionTools.ts
@@ -1,15 +1,15 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions, SettingTrigger, SettingTriggerMax } from "../settings/Settings.js";
 import { Dialog } from "./components/Dialog.js";
 import {
   SettingMaxTriggerListItem,
   type SettingMaxTriggerListItemOptions,
 } from "./components/SettingMaxTriggerListItem.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export const BuildSectionTools = {
   getBuildOption: (
-    host: KittenScientists,
+    parent: UiComponent,
     option: SettingTriggerMax,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: SettingTrigger,
@@ -19,14 +19,14 @@ export const BuildSectionTools = {
   ) => {
     const onSetMax = async () => {
       const value = await Dialog.prompt(
-        host,
-        host.engine.i18n("ui.max.prompt.absolute"),
-        host.engine.i18n("ui.max.build.prompt", [
+        parent,
+        parent.host.engine.i18n("ui.max.prompt.absolute"),
+        parent.host.engine.i18n("ui.max.build.prompt", [
           label,
-          host.renderAbsolute(option.max, locale.selected),
+          parent.host.renderAbsolute(option.max, locale.selected),
         ]),
-        host.renderAbsolute(option.max),
-        host.engine.i18n("ui.max.build.promptExplainer"),
+        parent.host.renderAbsolute(option.max),
+        parent.host.engine.i18n("ui.max.build.promptExplainer"),
       );
 
       if (value === undefined) {
@@ -42,20 +42,20 @@ export const BuildSectionTools = {
         option.enabled = false;
       }
 
-      option.max = host.parseAbsolute(value) ?? option.max;
+      option.max = parent.host.parseAbsolute(value) ?? option.max;
     };
 
-    const element = new SettingMaxTriggerListItem(host, option, locale, label, {
+    const element = new SettingMaxTriggerListItem(parent, option, locale, label, {
       delimiter: options?.delimiter,
       onCheck: (isBatchProcess?: boolean) => {
-        host.engine.imessage("status.sub.enable", [label]);
+        parent.host.engine.imessage("status.sub.enable", [label]);
         if (option.max === 0 && !isBatchProcess) {
           onSetMax();
         }
         options?.onCheck?.(isBatchProcess);
       },
       onUnCheck: (isBatchProcess?: boolean) => {
-        host.engine.imessage("status.sub.disable", [label]);
+        parent.host.engine.imessage("status.sub.disable", [label]);
         options?.onUnCheck?.(isBatchProcess);
       },
       onRefresh: () => {
@@ -70,36 +70,39 @@ export const BuildSectionTools = {
           option.trigger === -1;
       },
       onRefreshMax: () => {
-        element.maxButton.updateLabel(host.renderAbsolute(option.max));
+        element.maxButton.updateLabel(parent.host.renderAbsolute(option.max));
         element.maxButton.element[0].title =
           option.max < 0
-            ? host.engine.i18n("ui.max.build.titleInfinite", [label])
+            ? parent.host.engine.i18n("ui.max.build.titleInfinite", [label])
             : option.max === 0
-              ? host.engine.i18n("ui.max.build.titleZero", [label])
-              : host.engine.i18n("ui.max.build.title", [host.renderAbsolute(option.max), label]);
+              ? parent.host.engine.i18n("ui.max.build.titleZero", [label])
+              : parent.host.engine.i18n("ui.max.build.title", [
+                  parent.host.renderAbsolute(option.max),
+                  label,
+                ]);
       },
       onRefreshTrigger: () => {
-        element.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+        element.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger", [
           option.trigger < 0
             ? sectionSetting.trigger < 0
-              ? host.engine.i18n("ui.trigger.build.blocked", [sectionLabel])
-              : `${host.renderPercentage(sectionSetting.trigger, locale.selected, true)} (${host.engine.i18n("ui.trigger.build.inherited")})`
-            : host.renderPercentage(option.trigger, locale.selected, true),
+              ? parent.host.engine.i18n("ui.trigger.build.blocked", [sectionLabel])
+              : `${parent.host.renderPercentage(sectionSetting.trigger, locale.selected, true)} (${parent.host.engine.i18n("ui.trigger.build.inherited")})`
+            : parent.host.renderPercentage(option.trigger, locale.selected, true),
         ]);
       },
       onSetMax,
       onSetTrigger: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("ui.trigger.prompt.percentage"),
-          host.engine.i18n("ui.trigger.build.prompt", [
+          parent,
+          parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+          parent.host.engine.i18n("ui.trigger.build.prompt", [
             label,
             option.trigger !== -1
-              ? host.renderPercentage(option.trigger, locale.selected, true)
-              : host.engine.i18n("ui.trigger.build.inherited"),
+              ? parent.host.renderPercentage(option.trigger, locale.selected, true)
+              : parent.host.engine.i18n("ui.trigger.build.inherited"),
           ]),
-          option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
-          host.engine.i18n("ui.trigger.build.promptExplainer"),
+          option.trigger !== -1 ? parent.host.renderPercentage(option.trigger) : "",
+          parent.host.engine.i18n("ui.trigger.build.promptExplainer"),
         );
 
         if (value === undefined) {
@@ -111,7 +114,7 @@ export const BuildSectionTools = {
           return;
         }
 
-        option.trigger = host.parsePercentage(value);
+        option.trigger = parent.host.parsePercentage(value);
       },
       upgradeIndicator: options?.upgradeIndicator,
     });

--- a/source/ui/BuildSectionTools.ts
+++ b/source/ui/BuildSectionTools.ts
@@ -3,19 +3,14 @@ import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions, SettingTrigger, SettingTriggerMax } from "../settings/Settings.js";
 import { Dialog } from "./components/Dialog.js";
-import type { SettingListItemOptions } from "./components/SettingListItem.js";
-import type { SettingListItemOptionsMax } from "./components/SettingMaxListItem.js";
-import { SettingMaxTriggerListItem } from "./components/SettingMaxTriggerListItem.js";
-import type { SettingListItemOptionsTrigger } from "./components/SettingTriggerListItem.js";
-import type { UiComponent } from "./components/UiComponent.js";
+import {
+  SettingMaxTriggerListItem,
+  type SettingMaxTriggerListItemOptions,
+} from "./components/SettingMaxTriggerListItem.js";
 
 export const BuildSectionTools = {
   getBuildOption: <
-    TOptions extends SettingListItemOptions<UiComponent> &
-      SettingListItemOptionsMax &
-      SettingListItemOptionsTrigger = SettingListItemOptions<UiComponent> &
-      SettingListItemOptionsMax &
-      SettingListItemOptionsTrigger,
+    TOptions extends SettingMaxTriggerListItemOptions = SettingMaxTriggerListItemOptions,
   >(
     host: KittenScientists,
     option: SettingTriggerMax,

--- a/source/ui/BuildingUpgradeSettingsUi.ts
+++ b/source/ui/BuildingUpgradeSettingsUi.ts
@@ -34,7 +34,7 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: _item => {
+        onRefresh: () => {
           this.expando.ineffective =
             sectionSetting.enabled &&
             settings.enabled &&

--- a/source/ui/BuildingUpgradeSettingsUi.ts
+++ b/source/ui/BuildingUpgradeSettingsUi.ts
@@ -3,12 +3,11 @@ import type { KittenScientists } from "../KittenScientists.js";
 import type { BonfireSettings } from "../settings/BonfireSettings.js";
 import type { BuildingUpgradeSettings } from "../settings/BuildingUpgradeSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSettings> {
   constructor(
@@ -16,7 +15,7 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
     settings: BuildingUpgradeSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: BonfireSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade.buildings");
     super(

--- a/source/ui/BuildingUpgradeSettingsUi.ts
+++ b/source/ui/BuildingUpgradeSettingsUi.ts
@@ -56,6 +56,6 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
     for (const button of items) {
       itemsList.addChild(button.button);
     }
-    this.addChild(itemsList);
+    this.addChildContent(itemsList);
   }
 }

--- a/source/ui/BuildingUpgradeSettingsUi.ts
+++ b/source/ui/BuildingUpgradeSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { BonfireSettings } from "../settings/BonfireSettings.js";
 import type { BuildingUpgradeSettings } from "../settings/BuildingUpgradeSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -8,28 +7,29 @@ import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: BuildingUpgradeSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: BonfireSettings,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.upgrade.buildings");
+    const label = parent.host.engine.i18n("ui.upgrade.buildings");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -45,14 +45,14 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
 
     const items = [];
     for (const setting of Object.values(this.setting.buildings)) {
-      const label = host.engine.i18n(`$buildings.${setting.upgrade}.label`);
-      const button = new SettingListItem(host, setting, label, {
+      const label = parent.host.engine.i18n(`$buildings.${setting.upgrade}.label`);
+      const button = new SettingListItem(parent, setting, label, {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [label]);
+          parent.host.engine.imessage("status.sub.enable", [label]);
           this.refreshUi();
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [label]);
+          parent.host.engine.imessage("status.sub.disable", [label]);
           this.refreshUi();
         },
       });
@@ -61,7 +61,7 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
     }
     // Ensure buttons are added into UI with their labels alphabetized.
     items.sort((a, b) => a.label.localeCompare(b.label));
-    const itemsList = new SettingsList(host);
+    const itemsList = new SettingsList(parent);
     for (const button of items) {
       itemsList.addChild(button.button);
     }

--- a/source/ui/BuildingUpgradeSettingsUi.ts
+++ b/source/ui/BuildingUpgradeSettingsUi.ts
@@ -4,9 +4,9 @@ import type { BuildingUpgradeSettings } from "../settings/BuildingUpgradeSetting
 import type { SettingOptions } from "../settings/Settings.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSettings> {
@@ -15,23 +15,17 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
     settings: BuildingUpgradeSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: BonfireSettings,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.upgrade.buildings");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.expando.ineffective =
@@ -39,21 +33,18 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
             settings.enabled &&
             !Object.values(settings.buildings).some(building => building.enabled);
         },
-      }),
-      options,
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
     const items = [];
     for (const setting of Object.values(this.setting.buildings)) {
-      const label = parent.host.engine.i18n(`$buildings.${setting.upgrade}.label`);
-      const button = new SettingListItem(parent, setting, label, {
+      const label = this.host.engine.i18n(`$buildings.${setting.upgrade}.label`);
+      const button = new SettingListItem(this, setting, label, {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [label]);
-          this.refreshUi();
+          this.host.engine.imessage("status.sub.enable", [label]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [label]);
-          this.refreshUi();
+          this.host.engine.imessage("status.sub.disable", [label]);
         },
       });
 
@@ -61,7 +52,7 @@ export class BuildingUpgradeSettingsUi extends SettingsPanel<BuildingUpgradeSett
     }
     // Ensure buttons are added into UI with their labels alphabetized.
     items.sort((a, b) => a.label.localeCompare(b.label));
-    const itemsList = new SettingsList(parent);
+    const itemsList = new SettingsList(this);
     for (const button of items) {
       itemsList.addChild(button.button);
     }

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -5,11 +5,10 @@ import type { SettingMax, SettingOptions } from "../settings/Settings.js";
 import type { TradeSettings } from "../settings/TradeSettings.js";
 import stylesButton from "./components/Button.module.css";
 import { Dialog } from "./components/Dialog.js";
-import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingMaxListItem } from "./components/SettingMaxListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTriggerListItem> {
@@ -18,7 +17,6 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
     settings: EmbassySettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TradeSettings,
-    options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("option.embassies");
     super(
@@ -27,13 +25,9 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
       new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
@@ -61,22 +55,21 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
           settings.trigger = parent.host.parsePercentage(value);
         },
       }),
-      options,
     );
 
-    const listRaces = new SettingsList(parent, {
-      children: parent.host.game.diplomacy.races
+    const listRaces = new SettingsList(this).addChildren(
+      this.host.game.diplomacy.races
         .filter(item => item.name !== "leviathans" && !isNil(this.setting.races[item.name]))
         .map(race =>
           this._makeEmbassySetting(
-            parent,
+            this,
             this.setting.races[race.name],
             locale.selected,
             settings,
             race.title,
           ),
         ),
-    });
+    );
     this.addChild(listRaces);
   }
 

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -59,8 +59,6 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
           }
 
           settings.trigger = host.parsePercentage(value);
-
-          this.refreshUi();
         },
       }),
       options,
@@ -97,6 +95,7 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
         host.renderAbsolute(option.max),
         host.engine.i18n("ui.max.build.promptExplainer"),
       );
+
       if (value === undefined) {
         return;
       }
@@ -111,8 +110,6 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
       }
 
       option.max = host.parseAbsolute(value) ?? option.max;
-
-      this.refreshUi();
     };
 
     const element = new SettingMaxListItem(host, option, label, {

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { EmbassySettings } from "../settings/EmbassySettings.js";
@@ -44,8 +43,8 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
             settings.enabled &&
             !Object.values(settings.races).some(race => race.enabled);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.embassies.prompt"),
             host.engine.i18n("ui.trigger.embassies.promptTitle", [
@@ -53,18 +52,15 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
             ]),
             host.renderPercentage(settings.trigger),
             host.engine.i18n("ui.trigger.embassies.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined || value === "" || value.startsWith("-")) {
-                return;
-              }
+          );
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === undefined || value === "" || value.startsWith("-")) {
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
+
+          this.refreshUi();
         },
       }),
       options,
@@ -93,34 +89,30 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
     sectionSetting: EmbassySettings,
     label: string,
   ) {
-    const onSetMax = () => {
-      Dialog.prompt(
+    const onSetMax = async () => {
+      const value = await Dialog.prompt(
         host,
         host.engine.i18n("ui.max.prompt.absolute"),
         host.engine.i18n("ui.max.build.prompt", [label, host.renderAbsolute(option.max, locale)]),
         host.renderAbsolute(option.max),
         host.engine.i18n("ui.max.build.promptExplainer"),
-      )
-        .then(value => {
-          if (value === undefined) {
-            return;
-          }
+      );
+      if (value === undefined) {
+        return;
+      }
 
-          if (value === "" || value.startsWith("-")) {
-            option.max = -1;
-            return;
-          }
+      if (value === "" || value.startsWith("-")) {
+        option.max = -1;
+        return;
+      }
 
-          if (value === "0") {
-            option.enabled = false;
-          }
+      if (value === "0") {
+        option.enabled = false;
+      }
 
-          option.max = host.parseAbsolute(value) ?? option.max;
-        })
-        .then(() => {
-          this.refreshUi();
-        })
-        .catch(redirectErrorsToConsole(console));
+      option.max = host.parseAbsolute(value) ?? option.max;
+
+      this.refreshUi();
     };
 
     const element = new SettingMaxListItem(host, option, label, {

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -54,6 +54,7 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -70,7 +70,7 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
           ),
         ),
     );
-    this.addChild(listRaces);
+    this.addChildContent(listRaces);
   }
 
   private _makeEmbassySetting(

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -14,7 +14,7 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class EmbassySettingsUi extends SettingsPanel<EmbassySettings> {
+export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: EmbassySettings,
@@ -37,9 +37,8 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
 
           this.expando.ineffective =
             sectionSetting.enabled &&

--- a/source/ui/EmbassySettingsUi.ts
+++ b/source/ui/EmbassySettingsUi.ts
@@ -6,13 +6,12 @@ import type { EmbassySettings } from "../settings/EmbassySettings.js";
 import type { SettingMax, SettingOptions } from "../settings/Settings.js";
 import type { TradeSettings } from "../settings/TradeSettings.js";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingMaxListItem } from "./components/SettingMaxListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTriggerListItem> {
   constructor(
@@ -20,7 +19,7 @@ export class EmbassySettingsUi extends SettingsPanel<EmbassySettings, SettingTri
     settings: EmbassySettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TradeSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("option.embassies");
     super(

--- a/source/ui/EngineSettingsUi.ts
+++ b/source/ui/EngineSettingsUi.ts
@@ -12,7 +12,6 @@ export class EngineSettingsUi extends SettingListItem {
   constructor(parent: UiComponent, settings: EngineSettings) {
     const label = ucfirst(parent.host.engine.i18n("ui.engine"));
     super(parent, settings, label, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       onCheck: () => {
         parent.host.engine.start(true);
       },
@@ -21,7 +20,10 @@ export class EngineSettingsUi extends SettingListItem {
       },
     });
 
-    this.expando = new ExpandoButton(parent);
-    this.head.addChild(this.expando);
+    this.expando = new ExpandoButton(this);
+    this.addChildrenHead([
+      new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
+      this.expando,
+    ]);
   }
 }

--- a/source/ui/EngineSettingsUi.ts
+++ b/source/ui/EngineSettingsUi.ts
@@ -1,27 +1,27 @@
-import type { KittenScientists } from "../KittenScientists.js";
 import type { EngineSettings } from "../settings/EngineSettings.js";
 import { ucfirst } from "../tools/Format.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem } from "./components/SettingListItem.js";
+import type { UiComponent } from "./components/UiComponent.js";
 import { ExpandoButton } from "./components/buttons/ExpandoButton.js";
 
 export class EngineSettingsUi extends SettingListItem {
   readonly expando: ExpandoButton;
 
-  constructor(host: KittenScientists, settings: EngineSettings) {
-    const label = ucfirst(host.engine.i18n("ui.engine"));
-    super(host, settings, label, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+  constructor(parent: UiComponent, settings: EngineSettings) {
+    const label = ucfirst(parent.host.engine.i18n("ui.engine"));
+    super(parent, settings, label, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       onCheck: () => {
-        host.engine.start(true);
+        parent.host.engine.start(true);
       },
       onUnCheck: () => {
-        host.engine.stop(true);
+        parent.host.engine.stop(true);
       },
     });
 
-    this.expando = new ExpandoButton(host);
+    this.expando = new ExpandoButton(parent);
     this.head.addChild(this.expando);
   }
 }

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -16,7 +16,6 @@ import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 import { TextButton } from "./components/TextButton.js";
-import type { UiComponent } from "./components/UiComponent.js";
 
 export class InternalsUi extends SettingsPanel<EngineSettings> {
   constructor(
@@ -68,8 +67,8 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
                         })
                         .catch(redirectErrorsToConsole(console));
                     },
-                    onRefresh: (subject: UiComponent) => {
-                      (subject as TextButton).element.text(
+                    onRefresh() {
+                      this.element.text(
                         host.engine.i18n("ui.internals.interval", [settings.interval]),
                       );
                     },

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -60,8 +60,6 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
                       }
 
                       settings.interval = host.parseAbsolute(value) ?? settings.interval;
-
-                      this.refreshUi();
                     },
                     onRefresh() {
                       this.element.text(

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -32,7 +32,7 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
       }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    this.addChildren([
+    this.addChildrenContent([
       new SettingsList(parent, {
         hasDisableAll: false,
         hasEnableAll: false,

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -1,5 +1,5 @@
 import type { SupportedLocale } from "../Engine.js";
-import { type KittenScientists, ksVersion } from "../KittenScientists.js";
+import { ksVersion } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { EngineSettings } from "../settings/EngineSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -15,40 +15,41 @@ import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 import { TextButton } from "./components/TextButton.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class InternalsUi extends SettingsPanel<EngineSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: EngineSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
     super(
-      host,
+      parent,
       settings,
-      new LabelListItem(host, host.engine.i18n("ui.internals"), {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new LabelListItem(parent, parent.host.engine.i18n("ui.internals"), {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.Settings,
       }),
       {
         children: [
-          new SettingsList(host, {
+          new SettingsList(parent, {
             children: [
               new ButtonListItem(
-                host,
+                parent,
                 new TextButton(
-                  host,
-                  host.engine.i18n("ui.internals.interval", [settings.interval]),
+                  parent,
+                  parent.host.engine.i18n("ui.internals.interval", [settings.interval]),
                   {
                     onClick: async () => {
                       const value = await Dialog.prompt(
-                        host,
-                        host.engine.i18n("ui.internals.interval.prompt"),
-                        host.engine.i18n("ui.internals.interval.promptTitle", [
-                          host.renderAbsolute(settings.interval, locale.selected),
+                        parent,
+                        parent.host.engine.i18n("ui.internals.interval.prompt"),
+                        parent.host.engine.i18n("ui.internals.interval.promptTitle", [
+                          parent.host.renderAbsolute(settings.interval, locale.selected),
                         ]),
-                        host.renderAbsolute(settings.interval),
-                        host.engine.i18n("ui.internals.interval.promptExplainer"),
+                        parent.host.renderAbsolute(settings.interval),
+                        parent.host.engine.i18n("ui.internals.interval.promptExplainer"),
                       );
 
                       if (value === undefined || value === "" || value.startsWith("-")) {
@@ -59,36 +60,41 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
                         settings.enabled = false;
                       }
 
-                      settings.interval = host.parseAbsolute(value) ?? settings.interval;
+                      settings.interval = parent.host.parseAbsolute(value) ?? settings.interval;
                     },
                     onRefresh() {
                       this.element.text(
-                        host.engine.i18n("ui.internals.interval", [settings.interval]),
+                        parent.host.engine.i18n("ui.internals.interval", [settings.interval]),
                       );
                     },
                   },
                 ),
               ),
-              new Delimiter(host),
+              new Delimiter(parent),
 
-              new SettingListItem(host, settings.ksColumn, host.engine.i18n("ui.ksColumn"), {
-                onCheck: () => {
-                  host.rebuildUi();
+              new SettingListItem(
+                parent,
+                settings.ksColumn,
+                parent.host.engine.i18n("ui.ksColumn"),
+                {
+                  onCheck: () => {
+                    parent.host.rebuildUi();
+                  },
+                  onUnCheck: () => {
+                    parent.host.rebuildUi();
+                  },
                 },
-                onUnCheck: () => {
-                  host.rebuildUi();
+              ),
+              new Delimiter(parent),
+
+              new OptionsListItem(parent, parent.host.engine.i18n("ui.language"), settings.locale, {
+                onCheck: () => {
+                  parent.host.rebuildUi();
                 },
               }),
-              new Delimiter(host),
+              new Delimiter(parent),
 
-              new OptionsListItem(host, host.engine.i18n("ui.language"), settings.locale, {
-                onCheck: () => {
-                  host.rebuildUi();
-                },
-              }),
-              new Delimiter(host),
-
-              new LabelListItem(host, `Kitten Scientists ${ksVersion("v")}`),
+              new LabelListItem(parent, `Kitten Scientists ${ksVersion("v")}`),
             ],
             hasDisableAll: false,
             hasEnableAll: false,

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import { type KittenScientists, ksVersion } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -41,8 +40,8 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
                   host,
                   host.engine.i18n("ui.internals.interval", [settings.interval]),
                   {
-                    onClick: () => {
-                      Dialog.prompt(
+                    onClick: async () => {
+                      const value = await Dialog.prompt(
                         host,
                         host.engine.i18n("ui.internals.interval.prompt"),
                         host.engine.i18n("ui.internals.interval.promptTitle", [
@@ -50,22 +49,19 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
                         ]),
                         host.renderAbsolute(settings.interval),
                         host.engine.i18n("ui.internals.interval.promptExplainer"),
-                      )
-                        .then(value => {
-                          if (value === undefined || value === "" || value.startsWith("-")) {
-                            return;
-                          }
+                      );
 
-                          if (value === "0") {
-                            settings.enabled = false;
-                          }
+                      if (value === undefined || value === "" || value.startsWith("-")) {
+                        return;
+                      }
 
-                          settings.interval = host.parseAbsolute(value) ?? settings.interval;
-                        })
-                        .then(() => {
-                          this.refreshUi();
-                        })
-                        .catch(redirectErrorsToConsole(console));
+                      if (value === "0") {
+                        settings.enabled = false;
+                      }
+
+                      settings.interval = host.parseAbsolute(value) ?? settings.interval;
+
+                      this.refreshUi();
                     },
                     onRefresh() {
                       this.element.text(

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -27,80 +27,72 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
       parent,
       settings,
       new LabelListItem(parent, parent.host.engine.i18n("ui.internals"), {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.Settings,
-      }),
-      {
-        children: [
-          new SettingsList(parent, {
-            children: [
-              new ButtonListItem(
-                parent,
-                new TextButton(
-                  parent,
-                  parent.host.engine.i18n("ui.internals.interval", [settings.interval]),
-                  {
-                    onClick: async () => {
-                      const value = await Dialog.prompt(
-                        parent,
-                        parent.host.engine.i18n("ui.internals.interval.prompt"),
-                        parent.host.engine.i18n("ui.internals.interval.promptTitle", [
-                          parent.host.renderAbsolute(settings.interval, locale.selected),
-                        ]),
-                        parent.host.renderAbsolute(settings.interval),
-                        parent.host.engine.i18n("ui.internals.interval.promptExplainer"),
-                      );
-
-                      if (value === undefined || value === "" || value.startsWith("-")) {
-                        return;
-                      }
-
-                      if (value === "0") {
-                        settings.enabled = false;
-                      }
-
-                      settings.interval = parent.host.parseAbsolute(value) ?? settings.interval;
-                    },
-                    onRefresh() {
-                      this.element.text(
-                        parent.host.engine.i18n("ui.internals.interval", [settings.interval]),
-                      );
-                    },
-                  },
-                ),
-              ),
-              new Delimiter(parent),
-
-              new SettingListItem(
-                parent,
-                settings.ksColumn,
-                parent.host.engine.i18n("ui.ksColumn"),
-                {
-                  onCheck: () => {
-                    parent.host.rebuildUi();
-                  },
-                  onUnCheck: () => {
-                    parent.host.rebuildUi();
-                  },
-                },
-              ),
-              new Delimiter(parent),
-
-              new OptionsListItem(parent, parent.host.engine.i18n("ui.language"), settings.locale, {
-                onCheck: () => {
-                  parent.host.rebuildUi();
-                },
-              }),
-              new Delimiter(parent),
-
-              new LabelListItem(parent, `Kitten Scientists ${ksVersion("v")}`),
-            ],
-            hasDisableAll: false,
-            hasEnableAll: false,
-          }),
-        ],
-      },
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
+
+    this.addChildren([
+      new SettingsList(parent, {
+        hasDisableAll: false,
+        hasEnableAll: false,
+      }).addChildren([
+        new ButtonListItem(
+          parent,
+          new TextButton(
+            parent,
+            parent.host.engine.i18n("ui.internals.interval", [settings.interval]),
+            {
+              onClick: async () => {
+                const value = await Dialog.prompt(
+                  parent,
+                  parent.host.engine.i18n("ui.internals.interval.prompt"),
+                  parent.host.engine.i18n("ui.internals.interval.promptTitle", [
+                    parent.host.renderAbsolute(settings.interval, locale.selected),
+                  ]),
+                  parent.host.renderAbsolute(settings.interval),
+                  parent.host.engine.i18n("ui.internals.interval.promptExplainer"),
+                );
+
+                if (value === undefined || value === "" || value.startsWith("-")) {
+                  return;
+                }
+
+                if (value === "0") {
+                  settings.enabled = false;
+                }
+
+                settings.interval = parent.host.parseAbsolute(value) ?? settings.interval;
+              },
+              onRefresh() {
+                this.element.text(
+                  parent.host.engine.i18n("ui.internals.interval", [settings.interval]),
+                );
+              },
+            },
+          ),
+        ),
+        new Delimiter(parent),
+
+        new SettingListItem(parent, settings.ksColumn, parent.host.engine.i18n("ui.ksColumn"), {
+          onCheck: () => {
+            parent.host.rebuildUi();
+          },
+          onUnCheck: () => {
+            parent.host.rebuildUi();
+          },
+        }),
+        new Delimiter(parent),
+
+        new OptionsListItem(parent, parent.host.engine.i18n("ui.language"), settings.locale, {
+          onCheck: () => {
+            parent.host.rebuildUi();
+          },
+        }),
+        new Delimiter(parent),
+
+        new LabelListItem(parent, `Kitten Scientists ${ksVersion("v")}`),
+      ]),
+    ]);
   }
 }

--- a/source/ui/LogFilterSettingsUi.ts
+++ b/source/ui/LogFilterSettingsUi.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../KittenScientists.js";
 import { FilterItems, type LogFilterSettings } from "../settings/LogFilterSettings.js";
 import { Container } from "./components/Container.js";
 import { ExplainerListItem } from "./components/ExplainerListItem.js";
@@ -6,26 +5,27 @@ import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class LogFiltersSettingsUi extends SettingsPanel<LogFilterSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: LogFilterSettings,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.filter");
+    const label = parent.host.engine.i18n("ui.filter");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -33,34 +33,38 @@ export class LogFiltersSettingsUi extends SettingsPanel<LogFilterSettings> {
     );
 
     this.addChild(
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new SettingListItem(host, settings.disableKGLog, host.engine.i18n("filter.allKG")),
+          new SettingListItem(
+            parent,
+            settings.disableKGLog,
+            parent.host.engine.i18n("filter.allKG"),
+          ),
         ],
         hasDisableAll: false,
         hasEnableAll: false,
       }),
     );
 
-    const listFilters = new SettingsList(host, {
+    const listFilters = new SettingsList(parent, {
       children: FilterItems.map(item => {
-        return { name: item, label: host.engine.i18n(`filter.${item}`) };
+        return { name: item, label: parent.host.engine.i18n(`filter.${item}`) };
       })
         .sort((a, b) => a.label.localeCompare(b.label))
         .map(
           item =>
-            new SettingListItem(host, this.setting.filters[item.name], item.label, {
+            new SettingListItem(parent, this.setting.filters[item.name], item.label, {
               onCheck: () => {
-                host.engine.imessage("filter.enable", [item.label]);
+                parent.host.engine.imessage("filter.enable", [item.label]);
               },
               onUnCheck: () => {
-                host.engine.imessage("filter.disable", [item.label]);
+                parent.host.engine.imessage("filter.disable", [item.label]);
               },
             }),
         ),
     });
     this.addChild(listFilters);
 
-    this.addChild(new ExplainerListItem(host, "filter.explainer"));
+    this.addChild(new ExplainerListItem(parent, "filter.explainer"));
   }
 }

--- a/source/ui/LogFilterSettingsUi.ts
+++ b/source/ui/LogFilterSettingsUi.ts
@@ -2,69 +2,55 @@ import { FilterItems, type LogFilterSettings } from "../settings/LogFilterSettin
 import { Container } from "./components/Container.js";
 import { ExplainerListItem } from "./components/ExplainerListItem.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class LogFiltersSettingsUi extends SettingsPanel<LogFilterSettings> {
-  constructor(
-    parent: UiComponent,
-    settings: LogFilterSettings,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
-  ) {
+  constructor(parent: UiComponent, settings: LogFilterSettings) {
     const label = parent.host.engine.i18n("ui.filter");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
-      }),
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
     this.addChild(
-      new SettingsList(parent, {
-        children: [
-          new SettingListItem(
-            parent,
-            settings.disableKGLog,
-            parent.host.engine.i18n("filter.allKG"),
-          ),
-        ],
+      new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
-      }),
+      }).addChildren([
+        new SettingListItem(this, settings.disableKGLog, this.host.engine.i18n("filter.allKG")),
+      ]),
     );
 
-    const listFilters = new SettingsList(parent, {
-      children: FilterItems.map(item => {
-        return { name: item, label: parent.host.engine.i18n(`filter.${item}`) };
+    const listFilters = new SettingsList(this).addChildren(
+      FilterItems.map(item => {
+        return { name: item, label: this.host.engine.i18n(`filter.${item}`) };
       })
         .sort((a, b) => a.label.localeCompare(b.label))
         .map(
           item =>
-            new SettingListItem(parent, this.setting.filters[item.name], item.label, {
+            new SettingListItem(this, this.setting.filters[item.name], item.label, {
               onCheck: () => {
-                parent.host.engine.imessage("filter.enable", [item.label]);
+                this.host.engine.imessage("filter.enable", [item.label]);
               },
               onUnCheck: () => {
-                parent.host.engine.imessage("filter.disable", [item.label]);
+                this.host.engine.imessage("filter.disable", [item.label]);
               },
             }),
         ),
-    });
+    );
     this.addChild(listFilters);
 
-    this.addChild(new ExplainerListItem(parent, "filter.explainer"));
+    this.addChild(new ExplainerListItem(this, "filter.explainer"));
   }
 }

--- a/source/ui/LogFilterSettingsUi.ts
+++ b/source/ui/LogFilterSettingsUi.ts
@@ -1,18 +1,17 @@
 import type { KittenScientists } from "../KittenScientists.js";
 import { FilterItems, type LogFilterSettings } from "../settings/LogFilterSettings.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import { ExplainerListItem } from "./components/ExplainerListItem.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class LogFiltersSettingsUi extends SettingsPanel<LogFilterSettings> {
   constructor(
     host: KittenScientists,
     settings: LogFilterSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.filter");
     super(

--- a/source/ui/LogFilterSettingsUi.ts
+++ b/source/ui/LogFilterSettingsUi.ts
@@ -23,7 +23,7 @@ export class LogFiltersSettingsUi extends SettingsPanel<LogFilterSettings> {
       }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
@@ -49,8 +49,8 @@ export class LogFiltersSettingsUi extends SettingsPanel<LogFilterSettings> {
             }),
         ),
     );
-    this.addChild(listFilters);
+    this.addChildContent(listFilters);
 
-    this.addChild(new ExplainerListItem(this, "filter.explainer"));
+    this.addChildContent(new ExplainerListItem(this, "filter.explainer"));
   }
 }

--- a/source/ui/MissionSettingsUi.ts
+++ b/source/ui/MissionSettingsUi.ts
@@ -4,12 +4,11 @@ import type { KittenScientists } from "../KittenScientists.js";
 import type { MissionSettings } from "../settings/MissionSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { SpaceSettings } from "../settings/SpaceSettings.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
   private readonly _missions: Array<SettingListItem>;
@@ -19,7 +18,7 @@ export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
     settings: MissionSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: SpaceSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade.missions");
     super(

--- a/source/ui/MissionSettingsUi.ts
+++ b/source/ui/MissionSettingsUi.ts
@@ -55,6 +55,6 @@ export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
       );
 
     const itemsList = new SettingsList(this).addChildren(this._missions);
-    this.addChild(itemsList);
+    this.addChildContent(itemsList);
   }
 }

--- a/source/ui/MissionSettingsUi.ts
+++ b/source/ui/MissionSettingsUi.ts
@@ -5,9 +5,9 @@ import type { SettingOptions } from "../settings/Settings.js";
 import type { SpaceSettings } from "../settings/SpaceSettings.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
@@ -18,23 +18,17 @@ export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
     settings: MissionSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: SpaceSettings,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.upgrade.missions");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.expando.ineffective =
@@ -42,26 +36,25 @@ export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
             settings.enabled &&
             !Object.values(settings.missions).some(mission => mission.enabled);
         },
-      }),
-      options,
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
     // Missions should be sorted by KG. For example, when going to the sun just choose the top five Checkbox instead of looking through the list
-    this._missions = parent.host.game.space.programs
+    this._missions = this.host.game.space.programs
       .filter(item => !isNil(this.setting.missions[item.name]))
       .map(
         mission =>
-          new SettingListItem(parent, this.setting.missions[mission.name], mission.label, {
+          new SettingListItem(this, this.setting.missions[mission.name], mission.label, {
             onCheck: () => {
-              parent.host.engine.imessage("status.sub.enable", [mission.label]);
+              this.host.engine.imessage("status.sub.enable", [mission.label]);
             },
             onUnCheck: () => {
-              parent.host.engine.imessage("status.sub.disable", [mission.label]);
+              this.host.engine.imessage("status.sub.disable", [mission.label]);
             },
           }),
       );
 
-    const itemsList = new SettingsList(parent, { children: this._missions });
+    const itemsList = new SettingsList(this).addChildren(this._missions);
     this.addChild(itemsList);
   }
 }

--- a/source/ui/MissionSettingsUi.ts
+++ b/source/ui/MissionSettingsUi.ts
@@ -37,7 +37,7 @@ export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: _item => {
+        onRefresh: () => {
           this.expando.ineffective =
             sectionSetting.enabled &&
             settings.enabled &&

--- a/source/ui/MissionSettingsUi.ts
+++ b/source/ui/MissionSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { MissionSettings } from "../settings/MissionSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { SpaceSettings } from "../settings/SpaceSettings.js";
@@ -9,30 +8,31 @@ import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
   private readonly _missions: Array<SettingListItem>;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: MissionSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: SpaceSettings,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.upgrade.missions");
+    const label = parent.host.engine.i18n("ui.upgrade.missions");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -47,21 +47,21 @@ export class MissionSettingsUi extends SettingsPanel<MissionSettings> {
     );
 
     // Missions should be sorted by KG. For example, when going to the sun just choose the top five Checkbox instead of looking through the list
-    this._missions = host.game.space.programs
+    this._missions = parent.host.game.space.programs
       .filter(item => !isNil(this.setting.missions[item.name]))
       .map(
         mission =>
-          new SettingListItem(host, this.setting.missions[mission.name], mission.label, {
+          new SettingListItem(parent, this.setting.missions[mission.name], mission.label, {
             onCheck: () => {
-              host.engine.imessage("status.sub.enable", [mission.label]);
+              parent.host.engine.imessage("status.sub.enable", [mission.label]);
             },
             onUnCheck: () => {
-              host.engine.imessage("status.sub.disable", [mission.label]);
+              parent.host.engine.imessage("status.sub.disable", [mission.label]);
             },
           }),
       );
 
-    const itemsList = new SettingsList(host, { children: this._missions });
+    const itemsList = new SettingsList(parent, { children: this._missions });
     this.addChild(itemsList);
   }
 }

--- a/source/ui/PolicySettingsUi.ts
+++ b/source/ui/PolicySettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { PolicySettings } from "../settings/PolicySettings.js";
 import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -9,28 +8,29 @@ import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: PolicySettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ScienceSettings,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.upgrade.policies");
+    const label = parent.host.engine.i18n("ui.upgrade.policies");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -44,7 +44,7 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
       options,
     );
 
-    const policies = host.game.science.policies.filter(
+    const policies = parent.host.game.science.policies.filter(
       policy => !isNil(this.setting.policies[policy.name]),
     );
 
@@ -53,18 +53,18 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
     for (const policy of policies.sort((a, b) => a.label.localeCompare(b.label, locale.selected))) {
       const option = this.setting.policies[policy.name];
 
-      const element = new SettingListItem(host, option, policy.label, {
+      const element = new SettingListItem(parent, option, policy.label, {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [policy.label]);
+          parent.host.engine.imessage("status.sub.enable", [policy.label]);
           this.refreshUi();
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [policy.label]);
+          parent.host.engine.imessage("status.sub.disable", [policy.label]);
           this.refreshUi();
         },
       });
 
-      if (host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== policy.label[0]) {
           element.element.addClass(stylesLabelListItem.splitter);
         }
@@ -75,6 +75,6 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
       lastLabel = policy.label;
     }
 
-    this.addChild(new SettingsList(host, { children: items }));
+    this.addChild(new SettingsList(parent, { children: items }));
   }
 }

--- a/source/ui/PolicySettingsUi.ts
+++ b/source/ui/PolicySettingsUi.ts
@@ -66,6 +66,6 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
       lastLabel = policy.label;
     }
 
-    this.addChild(new SettingsList(this).addChildren(items));
+    this.addChildContent(new SettingsList(this).addChildren(items));
   }
 }

--- a/source/ui/PolicySettingsUi.ts
+++ b/source/ui/PolicySettingsUi.ts
@@ -5,9 +5,9 @@ import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
@@ -16,23 +16,17 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
     settings: PolicySettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ScienceSettings,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.upgrade.policies");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.expando.ineffective =
@@ -40,11 +34,10 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
             settings.enabled &&
             !Object.values(settings.policies).some(policy => policy.enabled);
         },
-      }),
-      options,
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    const policies = parent.host.game.science.policies.filter(
+    const policies = this.host.game.science.policies.filter(
       policy => !isNil(this.setting.policies[policy.name]),
     );
 
@@ -53,18 +46,16 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
     for (const policy of policies.sort((a, b) => a.label.localeCompare(b.label, locale.selected))) {
       const option = this.setting.policies[policy.name];
 
-      const element = new SettingListItem(parent, option, policy.label, {
+      const element = new SettingListItem(this, option, policy.label, {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [policy.label]);
-          this.refreshUi();
+          this.host.engine.imessage("status.sub.enable", [policy.label]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [policy.label]);
-          this.refreshUi();
+          this.host.engine.imessage("status.sub.disable", [policy.label]);
         },
       });
 
-      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (this.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== policy.label[0]) {
           element.element.addClass(stylesLabelListItem.splitter);
         }
@@ -75,6 +66,6 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
       lastLabel = policy.label;
     }
 
-    this.addChild(new SettingsList(parent, { children: items }));
+    this.addChild(new SettingsList(this).addChildren(items));
   }
 }

--- a/source/ui/PolicySettingsUi.ts
+++ b/source/ui/PolicySettingsUi.ts
@@ -35,7 +35,7 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: _item => {
+        onRefresh: () => {
           this.expando.ineffective =
             sectionSetting.enabled &&
             settings.enabled &&

--- a/source/ui/PolicySettingsUi.ts
+++ b/source/ui/PolicySettingsUi.ts
@@ -4,12 +4,11 @@ import type { KittenScientists } from "../KittenScientists.js";
 import type { PolicySettings } from "../settings/PolicySettings.js";
 import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
   constructor(
@@ -17,7 +16,7 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
     settings: PolicySettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ScienceSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade.policies");
     super(

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -49,8 +49,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -18,7 +18,7 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class ReligionSettingsUi extends SettingsPanel<ReligionSettings> {
+export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingTriggerListItem> {
   private readonly _unicornBuildings: Map<
     ZigguratUpgrade | "unicornPasture",
     SettingMaxTriggerListItem
@@ -29,7 +29,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings> {
     host: KittenScientists,
     settings: ReligionSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: PanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.faith");
     super(
@@ -46,9 +46,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger: item => {
           item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
@@ -244,8 +243,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings> {
               onUnCheck: () => {
                 host.engine.imessage("status.sub.disable", [label]);
               },
-              onRefresh: element => {
-                (element as SettingTriggerListItem).triggerButton.inactive =
+              onRefresh: () => {
+                this.settingItem.triggerButton.inactive =
                   !this.setting[item].enabled || this.setting[item].trigger === -1;
               },
               onSetTrigger: () => {

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -8,7 +8,7 @@ import { ReligionOptions, UnicornItems, type ZigguratUpgrade } from "../types/in
 import { BuildSectionTools } from "./BuildSectionTools.js";
 import stylesTimeSkipHeatSettings from "./TimeSkipHeatSettingsUi.module.css";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
+import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { Delimiter } from "./components/Delimiter.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
@@ -29,7 +29,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
     host: KittenScientists,
     settings: ReligionSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: PanelOptions & SettingListItemOptions,
+    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.faith");
     super(

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -6,11 +6,10 @@ import { ReligionOptions, UnicornItems, type ZigguratUpgrade } from "../types/in
 import { BuildSectionTools } from "./BuildSectionTools.js";
 import stylesTimeSkipHeatSettings from "./TimeSkipHeatSettingsUi.module.css";
 import stylesButton from "./components/Button.module.css";
-import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { Delimiter } from "./components/Delimiter.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import type { SettingMaxTriggerListItem } from "./components/SettingMaxTriggerListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
@@ -28,7 +27,6 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
     parent: UiComponent,
     settings: ReligionSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.faith");
     super(
@@ -37,13 +35,9 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
       new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
@@ -89,15 +83,15 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
       [
         "unicornPasture",
         BuildSectionTools.getBuildOption(
-          parent,
+          this,
           this.setting.buildings.unicornPasture,
           locale,
           this.setting,
-          parent.host.engine.i18n("$buildings.unicornPasture.label"),
+          this.host.engine.i18n("$buildings.unicornPasture.label"),
           label,
         ),
       ],
-      ...parent.host.game.religion.zigguratUpgrades
+      ...this.host.game.religion.zigguratUpgrades
         .filter(
           item => unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
         )
@@ -106,7 +100,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
             [
               zigguratUpgrade.name,
               BuildSectionTools.getBuildOption(
-                parent,
+                this,
                 this.setting.buildings[zigguratUpgrade.name],
                 locale,
                 this.setting,
@@ -118,94 +112,31 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
     ]);
 
     this._bestUnicornBuilding = new SettingListItem(
-      parent,
+      this,
       this.setting.bestUnicornBuilding,
-      parent.host.engine.i18n("option.faith.best.unicorn"),
+      this.host.engine.i18n("option.faith.best.unicorn"),
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.faith.best.unicorn"),
+          this.host.engine.imessage("status.sub.enable", [
+            this.host.engine.i18n("option.faith.best.unicorn"),
           ]);
           for (const building of this._unicornBuildings.values()) {
             building.setting.enabled = true;
             building.setting.max = -1;
             building.setting.trigger = -1;
           }
-          this.refreshUi();
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.faith.best.unicorn"),
+          this.host.engine.imessage("status.sub.disable", [
+            this.host.engine.i18n("option.faith.best.unicorn"),
           ]);
-          this.refreshUi();
         },
         upgradeIndicator: true,
       },
     );
 
     this.addChildren([
-      new SettingsList(parent, {
-        children: [
-          new HeaderListItem(parent, parent.host.engine.i18n("$religion.panel.ziggurat.label")),
-          ...this._unicornBuildings.values(),
-          this._bestUnicornBuilding,
-          new Delimiter(parent),
-
-          ...parent.host.game.religion.zigguratUpgrades
-            .filter(
-              item =>
-                !unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
-            )
-            .map(upgrade =>
-              BuildSectionTools.getBuildOption(
-                parent,
-                this.setting.buildings[upgrade.name],
-                locale,
-                this.setting,
-                upgrade.label,
-                label,
-              ),
-            ),
-          new Delimiter(parent),
-
-          new HeaderListItem(
-            parent,
-            parent.host.engine.i18n("$religion.panel.orderOfTheSun.label"),
-          ),
-          ...parent.host.game.religion.religionUpgrades
-            .filter(item => !isNil(this.setting.buildings[item.name]))
-            .map(upgrade =>
-              BuildSectionTools.getBuildOption(
-                parent,
-                this.setting.buildings[upgrade.name],
-                locale,
-                this.setting,
-                upgrade.label,
-                label,
-                {
-                  delimiter:
-                    upgrade.name === parent.host.game.religion.religionUpgrades.at(-1)?.name,
-                },
-              ),
-            ),
-
-          new HeaderListItem(
-            parent,
-            parent.host.engine.i18n("$religion.panel.cryptotheology.label"),
-          ),
-          ...parent.host.game.religion.transcendenceUpgrades
-            .filter(item => !isNil(this.setting.buildings[item.name]))
-            .map(upgrade =>
-              BuildSectionTools.getBuildOption(
-                parent,
-                this.setting.buildings[upgrade.name],
-                locale,
-                this.setting,
-                upgrade.label,
-                label,
-              ),
-            ),
-        ],
+      new SettingsList(this, {
         onEnableAll: () => {
           this.refreshUi();
         },
@@ -220,86 +151,133 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
           });
           this.refreshUi();
         },
-      }),
+      }).addChildren([
+        new HeaderListItem(this, this.host.engine.i18n("$religion.panel.ziggurat.label")),
+        ...this._unicornBuildings.values(),
+        this._bestUnicornBuilding,
+        new Delimiter(this),
 
-      new SettingsList(parent, {
-        children: [
-          new HeaderListItem(parent, parent.host.engine.i18n("ui.additional")),
-          ...ReligionOptions.map(item => {
-            const label = parent.host.engine.i18n(`option.faith.${item}`);
-            if (item === "transcend") {
-              return new SettingListItem(parent, this.setting[item], label, {
-                onCheck: () => {
-                  parent.host.engine.imessage("status.sub.enable", [label]);
-                },
-                onUnCheck: () => {
-                  parent.host.engine.imessage("status.sub.disable", [label]);
-                },
-              });
-            }
+        ...this.host.game.religion.zigguratUpgrades
+          .filter(
+            item => !unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
+          )
+          .map(upgrade =>
+            BuildSectionTools.getBuildOption(
+              this,
+              this.setting.buildings[upgrade.name],
+              locale,
+              this.setting,
+              upgrade.label,
+              label,
+            ),
+          ),
+        new Delimiter(this),
 
-            const element = new SettingTriggerListItem(parent, this.setting[item], locale, label, {
-              classes: [stylesButton.lastHeadAction],
-              onCheck: () => {
-                parent.host.engine.imessage("status.sub.enable", [label]);
+        new HeaderListItem(this, this.host.engine.i18n("$religion.panel.orderOfTheSun.label")),
+        ...this.host.game.religion.religionUpgrades
+          .filter(item => !isNil(this.setting.buildings[item.name]))
+          .map(upgrade =>
+            BuildSectionTools.getBuildOption(
+              this,
+              this.setting.buildings[upgrade.name],
+              locale,
+              this.setting,
+              upgrade.label,
+              label,
+              {
+                delimiter: upgrade.name === this.host.game.religion.religionUpgrades.at(-1)?.name,
               },
-              onUnCheck: () => {
-                parent.host.engine.imessage("status.sub.disable", [label]);
-              },
-              onRefresh: () => {
-                this.settingItem.triggerButton.inactive =
-                  !this.setting[item].enabled || this.setting[item].trigger === -1;
-              },
-              onSetTrigger: async () => {
-                const value = await Dialog.prompt(
-                  parent,
-                  parent.host.engine.i18n(
-                    element.triggerButton.behavior === "integer"
-                      ? "ui.trigger.setinteger"
-                      : "ui.trigger.setpercentage",
-                    [label],
-                  ),
-                  parent.host.engine.i18n("ui.trigger.build.prompt", [
-                    label,
-                    element.triggerButton.behavior === "integer"
-                      ? parent.host.renderAbsolute(this.setting[item].trigger, locale.selected)
-                      : parent.host.renderPercentage(
-                          this.setting[item].trigger,
-                          locale.selected,
-                          true,
-                        ),
-                  ]),
-                  element.triggerButton.behavior === "integer"
-                    ? parent.host.renderAbsolute(this.setting[item].trigger)
-                    : parent.host.renderPercentage(this.setting[item].trigger),
-                  parent.host.engine.i18n(
-                    element.triggerButton.behavior === "integer"
-                      ? "ui.trigger.setinteger.promptExplainer"
-                      : "ui.trigger.setpercentage.promptExplainer",
-                  ),
-                );
+            ),
+          ),
 
-                if (value === undefined || value === "" || value.startsWith("-")) {
-                  return;
-                }
+        new HeaderListItem(this, this.host.engine.i18n("$religion.panel.cryptotheology.label")),
+        ...this.host.game.religion.transcendenceUpgrades
+          .filter(item => !isNil(this.setting.buildings[item.name]))
+          .map(upgrade =>
+            BuildSectionTools.getBuildOption(
+              this,
+              this.setting.buildings[upgrade.name],
+              locale,
+              this.setting,
+              upgrade.label,
+              label,
+            ),
+          ),
+      ]),
 
-                this.setting[item].trigger =
-                  (element.triggerButton.behavior === "integer"
-                    ? parent.host.parseAbsolute(value)
-                    : parent.host.parsePercentage(value)) ?? this.setting[item].trigger;
-              },
-            });
-            element.triggerButton.element.addClass(stylesButton.lastHeadAction);
-            return element;
-          }),
-        ],
+      new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
-      }),
+      }).addChildren([
+        new HeaderListItem(this, this.host.engine.i18n("ui.additional")),
+        ...ReligionOptions.map(item => {
+          const label = this.host.engine.i18n(`option.faith.${item}`);
+          if (item === "transcend") {
+            return new SettingListItem(this, this.setting[item], label, {
+              onCheck: () => {
+                this.host.engine.imessage("status.sub.enable", [label]);
+              },
+              onUnCheck: () => {
+                this.host.engine.imessage("status.sub.disable", [label]);
+              },
+            });
+          }
+
+          const element = new SettingTriggerListItem(this, this.setting[item], locale, label, {
+            classes: [stylesButton.lastHeadAction],
+            onCheck: () => {
+              this.host.engine.imessage("status.sub.enable", [label]);
+            },
+            onUnCheck: () => {
+              this.host.engine.imessage("status.sub.disable", [label]);
+            },
+            onRefresh: () => {
+              this.settingItem.triggerButton.inactive =
+                !this.setting[item].enabled || this.setting[item].trigger === -1;
+            },
+            onSetTrigger: async () => {
+              const value = await Dialog.prompt(
+                this,
+                this.host.engine.i18n(
+                  element.triggerButton.behavior === "integer"
+                    ? "ui.trigger.setinteger"
+                    : "ui.trigger.setpercentage",
+                  [label],
+                ),
+                this.host.engine.i18n("ui.trigger.build.prompt", [
+                  label,
+                  element.triggerButton.behavior === "integer"
+                    ? this.host.renderAbsolute(this.setting[item].trigger, locale.selected)
+                    : this.host.renderPercentage(this.setting[item].trigger, locale.selected, true),
+                ]),
+                element.triggerButton.behavior === "integer"
+                  ? this.host.renderAbsolute(this.setting[item].trigger)
+                  : this.host.renderPercentage(this.setting[item].trigger),
+                this.host.engine.i18n(
+                  element.triggerButton.behavior === "integer"
+                    ? "ui.trigger.setinteger.promptExplainer"
+                    : "ui.trigger.setpercentage.promptExplainer",
+                ),
+              );
+
+              if (value === undefined || value === "" || value.startsWith("-")) {
+                return;
+              }
+
+              this.setting[item].trigger =
+                (element.triggerButton.behavior === "integer"
+                  ? this.host.parseAbsolute(value)
+                  : this.host.parsePercentage(value)) ?? this.setting[item].trigger;
+            },
+          });
+          element.triggerButton.element.addClass(stylesButton.lastHeadAction);
+          return element;
+        }),
+      ]),
     ]);
   }
 
-  override refreshUi() {
+  refreshUi() {
     for (const [buildingName, building] of this._unicornBuildings.entries()) {
       building.readOnly = this._bestUnicornBuilding.setting.enabled;
       building.maxButton.readOnly = this._bestUnicornBuilding.setting.enabled;
@@ -317,6 +295,5 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
         building.elementLabel.removeClass(stylesTimeSkipHeatSettings.active);
       }
     }
-    super.refreshUi();
   }
 }

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { ReligionSettings } from "../settings/ReligionSettings.js";
@@ -56,8 +55,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -68,23 +67,18 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
         },
       }),
     );
@@ -247,8 +241,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
                 this.settingItem.triggerButton.inactive =
                   !this.setting[item].enabled || this.setting[item].trigger === -1;
               },
-              onSetTrigger: () => {
-                Dialog.prompt(
+              onSetTrigger: async () => {
+                const value = await Dialog.prompt(
                   host,
                   host.engine.i18n(
                     element.triggerButton.behavior === "integer"
@@ -270,21 +264,16 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
                       ? "ui.trigger.setinteger.promptExplainer"
                       : "ui.trigger.setpercentage.promptExplainer",
                   ),
-                )
-                  .then(value => {
-                    if (value === undefined || value === "" || value.startsWith("-")) {
-                      return;
-                    }
+                );
 
-                    this.setting[item].trigger =
-                      (element.triggerButton.behavior === "integer"
-                        ? host.parseAbsolute(value)
-                        : host.parsePercentage(value)) ?? this.setting[item].trigger;
-                  })
-                  .then(() => {
-                    this.refreshUi();
-                  })
-                  .catch(redirectErrorsToConsole(console));
+                if (value === undefined || value === "" || value.startsWith("-")) {
+                  return;
+                }
+
+                this.setting[item].trigger =
+                  (element.triggerButton.behavior === "integer"
+                    ? host.parseAbsolute(value)
+                    : host.parsePercentage(value)) ?? this.setting[item].trigger;
               },
             });
             element.triggerButton.element.addClass(stylesButton.lastHeadAction);

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -135,21 +135,15 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
       },
     );
 
-    this.addChildren([
+    this.addChildrenContent([
       new SettingsList(this, {
-        onEnableAll: () => {
-          this.refreshUi();
-        },
-        onDisableAll: () => {
-          this.refreshUi();
-        },
         onReset: () => {
           const defaults = new ReligionSettings();
           this.setting.load({
             buildings: defaults.buildings,
             bestUnicornBuilding: defaults.bestUnicornBuilding,
           });
-          this.refreshUi();
+          this.requestRefresh();
         },
       }).addChildren([
         new HeaderListItem(this, this.host.engine.i18n("$religion.panel.ziggurat.label")),
@@ -277,7 +271,9 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
     ]);
   }
 
-  refreshUi() {
+  refreshUi(): void {
+    super.refreshUi();
+
     for (const [buildingName, building] of this._unicornBuildings.entries()) {
       building.readOnly = this._bestUnicornBuilding.setting.enabled;
       building.maxButton.readOnly = this._bestUnicornBuilding.setting.enabled;

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { ReligionSettings } from "../settings/ReligionSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import { ReligionOptions, UnicornItems, type ZigguratUpgrade } from "../types/index.js";
@@ -16,6 +15,7 @@ import type { SettingMaxTriggerListItem } from "./components/SettingMaxTriggerLi
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingTriggerListItem> {
   private readonly _unicornBuildings: Map<
@@ -25,23 +25,23 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
   private readonly _bestUnicornBuilding: SettingListItem;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ReligionSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.faith");
+    const label = parent.host.engine.i18n("ui.faith");
     super(
-      host,
+      parent,
       settings,
-      new SettingTriggerListItem(host, settings, locale, label, {
+      new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -49,24 +49,24 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger() {
-          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+          this.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
-              ? host.engine.i18n("ui.trigger.section.inactive")
-              : host.renderPercentage(settings.trigger, locale.selected, true),
+              ? parent.host.engine.i18n("ui.trigger.section.inactive")
+              : parent.host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.percentage"),
-            host.engine.i18n("ui.trigger.section.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+            parent.host.engine.i18n("ui.trigger.section.prompt", [
               label,
               settings.trigger !== -1
-                ? host.renderPercentage(settings.trigger, locale.selected, true)
-                : host.engine.i18n("ui.infinity"),
+                ? parent.host.renderPercentage(settings.trigger, locale.selected, true)
+                : parent.host.engine.i18n("ui.infinity"),
             ]),
-            settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
-            host.engine.i18n("ui.trigger.section.promptExplainer"),
+            settings.trigger !== -1 ? parent.host.renderPercentage(settings.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.section.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -78,7 +78,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
             return;
           }
 
-          settings.trigger = host.parsePercentage(value);
+          settings.trigger = parent.host.parsePercentage(value);
         },
       }),
     );
@@ -89,15 +89,15 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
       [
         "unicornPasture",
         BuildSectionTools.getBuildOption(
-          host,
+          parent,
           this.setting.buildings.unicornPasture,
           locale,
           this.setting,
-          host.engine.i18n("$buildings.unicornPasture.label"),
+          parent.host.engine.i18n("$buildings.unicornPasture.label"),
           label,
         ),
       ],
-      ...host.game.religion.zigguratUpgrades
+      ...parent.host.game.religion.zigguratUpgrades
         .filter(
           item => unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
         )
@@ -106,7 +106,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
             [
               zigguratUpgrade.name,
               BuildSectionTools.getBuildOption(
-                host,
+                parent,
                 this.setting.buildings[zigguratUpgrade.name],
                 locale,
                 this.setting,
@@ -118,13 +118,13 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
     ]);
 
     this._bestUnicornBuilding = new SettingListItem(
-      host,
+      parent,
       this.setting.bestUnicornBuilding,
-      host.engine.i18n("option.faith.best.unicorn"),
+      parent.host.engine.i18n("option.faith.best.unicorn"),
       {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [
-            host.engine.i18n("option.faith.best.unicorn"),
+          parent.host.engine.imessage("status.sub.enable", [
+            parent.host.engine.i18n("option.faith.best.unicorn"),
           ]);
           for (const building of this._unicornBuildings.values()) {
             building.setting.enabled = true;
@@ -134,8 +134,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
           this.refreshUi();
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [
-            host.engine.i18n("option.faith.best.unicorn"),
+          parent.host.engine.imessage("status.sub.disable", [
+            parent.host.engine.i18n("option.faith.best.unicorn"),
           ]);
           this.refreshUi();
         },
@@ -144,21 +144,21 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
     );
 
     this.addChildren([
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new HeaderListItem(host, host.engine.i18n("$religion.panel.ziggurat.label")),
+          new HeaderListItem(parent, parent.host.engine.i18n("$religion.panel.ziggurat.label")),
           ...this._unicornBuildings.values(),
           this._bestUnicornBuilding,
-          new Delimiter(host),
+          new Delimiter(parent),
 
-          ...host.game.religion.zigguratUpgrades
+          ...parent.host.game.religion.zigguratUpgrades
             .filter(
               item =>
                 !unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
             )
             .map(upgrade =>
               BuildSectionTools.getBuildOption(
-                host,
+                parent,
                 this.setting.buildings[upgrade.name],
                 locale,
                 this.setting,
@@ -166,29 +166,38 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
                 label,
               ),
             ),
-          new Delimiter(host),
+          new Delimiter(parent),
 
-          new HeaderListItem(host, host.engine.i18n("$religion.panel.orderOfTheSun.label")),
-          ...host.game.religion.religionUpgrades
+          new HeaderListItem(
+            parent,
+            parent.host.engine.i18n("$religion.panel.orderOfTheSun.label"),
+          ),
+          ...parent.host.game.religion.religionUpgrades
             .filter(item => !isNil(this.setting.buildings[item.name]))
             .map(upgrade =>
               BuildSectionTools.getBuildOption(
-                host,
+                parent,
                 this.setting.buildings[upgrade.name],
                 locale,
                 this.setting,
                 upgrade.label,
                 label,
-                { delimiter: upgrade.name === host.game.religion.religionUpgrades.at(-1)?.name },
+                {
+                  delimiter:
+                    upgrade.name === parent.host.game.religion.religionUpgrades.at(-1)?.name,
+                },
               ),
             ),
 
-          new HeaderListItem(host, host.engine.i18n("$religion.panel.cryptotheology.label")),
-          ...host.game.religion.transcendenceUpgrades
+          new HeaderListItem(
+            parent,
+            parent.host.engine.i18n("$religion.panel.cryptotheology.label"),
+          ),
+          ...parent.host.game.religion.transcendenceUpgrades
             .filter(item => !isNil(this.setting.buildings[item.name]))
             .map(upgrade =>
               BuildSectionTools.getBuildOption(
-                host,
+                parent,
                 this.setting.buildings[upgrade.name],
                 locale,
                 this.setting,
@@ -213,29 +222,29 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
         },
       }),
 
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new HeaderListItem(host, host.engine.i18n("ui.additional")),
+          new HeaderListItem(parent, parent.host.engine.i18n("ui.additional")),
           ...ReligionOptions.map(item => {
-            const label = host.engine.i18n(`option.faith.${item}`);
+            const label = parent.host.engine.i18n(`option.faith.${item}`);
             if (item === "transcend") {
-              return new SettingListItem(host, this.setting[item], label, {
+              return new SettingListItem(parent, this.setting[item], label, {
                 onCheck: () => {
-                  host.engine.imessage("status.sub.enable", [label]);
+                  parent.host.engine.imessage("status.sub.enable", [label]);
                 },
                 onUnCheck: () => {
-                  host.engine.imessage("status.sub.disable", [label]);
+                  parent.host.engine.imessage("status.sub.disable", [label]);
                 },
               });
             }
 
-            const element = new SettingTriggerListItem(host, this.setting[item], locale, label, {
+            const element = new SettingTriggerListItem(parent, this.setting[item], locale, label, {
               classes: [stylesButton.lastHeadAction],
               onCheck: () => {
-                host.engine.imessage("status.sub.enable", [label]);
+                parent.host.engine.imessage("status.sub.enable", [label]);
               },
               onUnCheck: () => {
-                host.engine.imessage("status.sub.disable", [label]);
+                parent.host.engine.imessage("status.sub.disable", [label]);
               },
               onRefresh: () => {
                 this.settingItem.triggerButton.inactive =
@@ -243,23 +252,27 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
               },
               onSetTrigger: async () => {
                 const value = await Dialog.prompt(
-                  host,
-                  host.engine.i18n(
+                  parent,
+                  parent.host.engine.i18n(
                     element.triggerButton.behavior === "integer"
                       ? "ui.trigger.setinteger"
                       : "ui.trigger.setpercentage",
                     [label],
                   ),
-                  host.engine.i18n("ui.trigger.build.prompt", [
+                  parent.host.engine.i18n("ui.trigger.build.prompt", [
                     label,
                     element.triggerButton.behavior === "integer"
-                      ? host.renderAbsolute(this.setting[item].trigger, locale.selected)
-                      : host.renderPercentage(this.setting[item].trigger, locale.selected, true),
+                      ? parent.host.renderAbsolute(this.setting[item].trigger, locale.selected)
+                      : parent.host.renderPercentage(
+                          this.setting[item].trigger,
+                          locale.selected,
+                          true,
+                        ),
                   ]),
                   element.triggerButton.behavior === "integer"
-                    ? host.renderAbsolute(this.setting[item].trigger)
-                    : host.renderPercentage(this.setting[item].trigger),
-                  host.engine.i18n(
+                    ? parent.host.renderAbsolute(this.setting[item].trigger)
+                    : parent.host.renderPercentage(this.setting[item].trigger),
+                  parent.host.engine.i18n(
                     element.triggerButton.behavior === "integer"
                       ? "ui.trigger.setinteger.promptExplainer"
                       : "ui.trigger.setpercentage.promptExplainer",
@@ -272,8 +285,8 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
 
                 this.setting[item].trigger =
                   (element.triggerButton.behavior === "integer"
-                    ? host.parseAbsolute(value)
-                    : host.parsePercentage(value)) ?? this.setting[item].trigger;
+                    ? parent.host.parseAbsolute(value)
+                    : parent.host.parsePercentage(value)) ?? this.setting[item].trigger;
               },
             });
             element.triggerButton.element.addClass(stylesButton.lastHeadAction);

--- a/source/ui/ReligionSettingsUi.ts
+++ b/source/ui/ReligionSettingsUi.ts
@@ -74,6 +74,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -89,6 +90,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
           this.setting,
           this.host.engine.i18n("$buildings.unicornPasture.label"),
           label,
+          { renderLabelTrigger: false },
         ),
       ],
       ...this.host.game.religion.zigguratUpgrades
@@ -106,6 +108,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
                 this.setting,
                 zigguratUpgrade.label,
                 label,
+                { renderLabelTrigger: false },
               ),
             ] as [ZigguratUpgrade | "unicornPasture", SettingMaxTriggerListItem],
         ),
@@ -163,6 +166,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
               this.setting,
               upgrade.label,
               label,
+              { renderLabelTrigger: false },
             ),
           ),
         new Delimiter(this),
@@ -180,6 +184,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
               label,
               {
                 delimiter: upgrade.name === this.host.game.religion.religionUpgrades.at(-1)?.name,
+                renderLabelTrigger: false,
               },
             ),
           ),
@@ -195,6 +200,7 @@ export class ReligionSettingsUi extends SettingsPanel<ReligionSettings, SettingT
               this.setting,
               upgrade.label,
               label,
+              { renderLabelTrigger: false },
             ),
           ),
       ]),

--- a/source/ui/ResetBonfireSettingsUi.ts
+++ b/source/ui/ResetBonfireSettingsUi.ts
@@ -25,33 +25,34 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
   ) {
     const label = parent.host.engine.i18n("ui.build");
     super(parent, label, settings, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Bonfire,
     });
 
+    this.addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
+
     this._buildings = [];
-    for (const buildingGroup of parent.host.game.bld.buildingGroups) {
-      this._buildings.push(new HeaderListItem(parent, buildingGroup.title));
+    for (const buildingGroup of this.host.game.bld.buildingGroups) {
+      this._buildings.push(new HeaderListItem(this, buildingGroup.title));
       for (const building of buildingGroup.buildings) {
         if (building === "unicornPasture" || isNil(this.setting.buildings[building])) {
           continue;
         }
 
-        const meta = parent.host.game.bld.getBuildingExt(building).meta;
+        const meta = this.host.game.bld.getBuildingExt(building).meta;
         if (!isNil(meta.stages)) {
           const name = Object.values(this.setting.buildings).find(
             item => item.baseBuilding === building,
           )?.building as StagedBuilding;
           this._buildings.push(
             this._getResetOption(
-              parent,
+              this,
               this.setting.buildings[building],
               locale,
               settings,
               meta.stages[0].label,
             ),
             this._getResetOption(
-              parent,
+              this,
               this.setting.buildings[name],
               locale,
               settings,
@@ -63,7 +64,7 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
         } else if (!isNil(meta.label)) {
           this._buildings.push(
             this._getResetOption(
-              parent,
+              this,
               this.setting.buildings[building],
               locale,
               settings,
@@ -76,13 +77,13 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
       // Add padding after each group. Except for the last group, which ends the list.
       if (
         buildingGroup !==
-        parent.host.game.bld.buildingGroups[parent.host.game.bld.buildingGroups.length - 1]
+        this.host.game.bld.buildingGroups[this.host.game.bld.buildingGroups.length - 1]
       ) {
         this._buildings.at(-1)?.element.addClass(stylesDelimiter.delimiter);
       }
     }
 
-    const listBuildings = new SettingsList(parent);
+    const listBuildings = new SettingsList(this);
     listBuildings.addChildren(this._buildings);
     this.addChild(listBuildings);
   }

--- a/source/ui/ResetBonfireSettingsUi.ts
+++ b/source/ui/ResetBonfireSettingsUi.ts
@@ -131,8 +131,6 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
         }
 
         option.trigger = Number(value);
-
-        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetBonfireSettingsUi.ts
+++ b/source/ui/ResetBonfireSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResetBonfireSettings } from "../settings/ResetBonfireSettings.js";
 import type { SettingOptions, SettingTrigger } from "../settings/Settings.js";
@@ -14,44 +13,45 @@ import { IconSettingsPanel } from "./components/IconSettingsPanel.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettings> {
   private readonly _buildings: Array<HeaderListItem | SettingTriggerListItem>;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetBonfireSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("ui.build");
-    super(host, label, settings, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const label = parent.host.engine.i18n("ui.build");
+    super(parent, label, settings, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Bonfire,
     });
 
     this._buildings = [];
-    for (const buildingGroup of host.game.bld.buildingGroups) {
-      this._buildings.push(new HeaderListItem(host, buildingGroup.title));
+    for (const buildingGroup of parent.host.game.bld.buildingGroups) {
+      this._buildings.push(new HeaderListItem(parent, buildingGroup.title));
       for (const building of buildingGroup.buildings) {
         if (building === "unicornPasture" || isNil(this.setting.buildings[building])) {
           continue;
         }
 
-        const meta = host.game.bld.getBuildingExt(building).meta;
+        const meta = parent.host.game.bld.getBuildingExt(building).meta;
         if (!isNil(meta.stages)) {
           const name = Object.values(this.setting.buildings).find(
             item => item.baseBuilding === building,
           )?.building as StagedBuilding;
           this._buildings.push(
             this._getResetOption(
-              host,
+              parent,
               this.setting.buildings[building],
               locale,
               settings,
               meta.stages[0].label,
             ),
             this._getResetOption(
-              host,
+              parent,
               this.setting.buildings[name],
               locale,
               settings,
@@ -63,7 +63,7 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
         } else if (!isNil(meta.label)) {
           this._buildings.push(
             this._getResetOption(
-              host,
+              parent,
               this.setting.buildings[building],
               locale,
               settings,
@@ -74,18 +74,21 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
       }
 
       // Add padding after each group. Except for the last group, which ends the list.
-      if (buildingGroup !== host.game.bld.buildingGroups[host.game.bld.buildingGroups.length - 1]) {
+      if (
+        buildingGroup !==
+        parent.host.game.bld.buildingGroups[parent.host.game.bld.buildingGroups.length - 1]
+      ) {
         this._buildings.at(-1)?.element.addClass(stylesDelimiter.delimiter);
       }
     }
 
-    const listBuildings = new SettingsList(host);
+    const listBuildings = new SettingsList(parent);
     listBuildings.addChildren(this._buildings);
     this.addChild(listBuildings);
   }
 
   private _getResetOption(
-    host: KittenScientists,
+    parent: UiComponent,
     option: SettingTrigger,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ResetBonfireSettings,
@@ -93,13 +96,13 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
     delimiter = false,
     upgradeIndicator = false,
   ) {
-    const element = new SettingTriggerListItem(host, option, locale, label, {
+    const element = new SettingTriggerListItem(parent, option, locale, label, {
       delimiter,
       onCheck: () => {
-        host.engine.imessage("status.reset.check.enable", [label]);
+        parent.host.engine.imessage("status.reset.check.enable", [label]);
       },
       onUnCheck: () => {
-        host.engine.imessage("status.reset.check.disable", [label]);
+        parent.host.engine.imessage("status.reset.check.disable", [label]);
       },
       onRefresh: () => {
         element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -108,16 +111,16 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
       },
       onSetTrigger: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("ui.trigger.prompt.absolute"),
-          host.engine.i18n("ui.trigger.build.prompt", [
+          parent,
+          parent.host.engine.i18n("ui.trigger.prompt.absolute"),
+          parent.host.engine.i18n("ui.trigger.build.prompt", [
             label,
             option.trigger !== -1
-              ? host.renderAbsolute(option.trigger, locale.selected)
-              : host.engine.i18n("ui.trigger.inactive"),
+              ? parent.host.renderAbsolute(option.trigger, locale.selected)
+              : parent.host.engine.i18n("ui.trigger.inactive"),
           ]),
-          option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
-          host.engine.i18n("ui.trigger.reset.promptExplainer"),
+          option.trigger !== -1 ? parent.host.renderAbsolute(option.trigger) : "",
+          parent.host.engine.i18n("ui.trigger.reset.promptExplainer"),
         );
 
         if (value === undefined) {

--- a/source/ui/ResetBonfireSettingsUi.ts
+++ b/source/ui/ResetBonfireSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -107,8 +106,8 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
         element.triggerButton.ineffective =
           sectionSetting.enabled && option.enabled && option.trigger === -1;
       },
-      onSetTrigger: () => {
-        Dialog.prompt(
+      onSetTrigger: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.trigger.prompt.absolute"),
           host.engine.i18n("ui.trigger.build.prompt", [
@@ -119,24 +118,21 @@ export class ResetBonfireSettingsUi extends IconSettingsPanel<ResetBonfireSettin
           ]),
           option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
           host.engine.i18n("ui.trigger.reset.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              option.trigger = -1;
-              option.enabled = false;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            option.trigger = Number(value);
-          })
-          .then(() => {
-            element.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          option.trigger = -1;
+          option.enabled = false;
+          return;
+        }
+
+        option.trigger = Number(value);
+
+        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetReligionSettingsUi.ts
+++ b/source/ui/ResetReligionSettingsUi.ts
@@ -139,6 +139,7 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
           option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
           host.engine.i18n("ui.trigger.reset.promptExplainer"),
         );
+
         if (value === undefined) {
           return;
         }
@@ -150,8 +151,6 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
         }
 
         option.trigger = Number(value);
-
-        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetReligionSettingsUi.ts
+++ b/source/ui/ResetReligionSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResetReligionSettings } from "../settings/ResetReligionSettings.js";
 import type { SettingOptions, SettingTrigger } from "../settings/Settings.js";
@@ -14,85 +13,92 @@ import { IconSettingsPanel } from "./components/IconSettingsPanel.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetReligionSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("ui.faith");
-    super(host, label, settings, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const label = parent.host.engine.i18n("ui.faith");
+    super(parent, label, settings, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Religion,
     });
 
     const unicornsArray: Array<ZigguratUpgrade | "unicornPasture"> = [...UnicornItems];
 
     this.addChild(
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new HeaderListItem(host, host.engine.i18n("$religion.panel.ziggurat.label")),
+          new HeaderListItem(parent, parent.host.engine.i18n("$religion.panel.ziggurat.label")),
           this._getResetOption(
-            host,
+            parent,
             this.setting.buildings.unicornPasture,
             locale,
             settings,
-            host.engine.i18n("$buildings.unicornPasture.label"),
+            parent.host.engine.i18n("$buildings.unicornPasture.label"),
           ),
 
-          ...host.game.religion.zigguratUpgrades
+          ...parent.host.game.religion.zigguratUpgrades
             .filter(
               item =>
                 unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
             )
             .map(zigguratUpgrade =>
               this._getResetOption(
-                host,
+                parent,
                 this.setting.buildings[zigguratUpgrade.name],
                 locale,
                 settings,
                 zigguratUpgrade.label,
               ),
             ),
-          new Delimiter(host),
+          new Delimiter(parent),
 
-          ...host.game.religion.zigguratUpgrades
+          ...parent.host.game.religion.zigguratUpgrades
             .filter(
               item =>
                 !unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
             )
             .map(upgrade =>
               this._getResetOption(
-                host,
+                parent,
                 this.setting.buildings[upgrade.name],
                 locale,
                 settings,
                 upgrade.label,
               ),
             ),
-          new Delimiter(host),
+          new Delimiter(parent),
 
-          new HeaderListItem(host, host.engine.i18n("$religion.panel.orderOfTheSun.label")),
-          ...host.game.religion.religionUpgrades
+          new HeaderListItem(
+            parent,
+            parent.host.engine.i18n("$religion.panel.orderOfTheSun.label"),
+          ),
+          ...parent.host.game.religion.religionUpgrades
             .filter(item => !isNil(this.setting.buildings[item.name]))
             .map(upgrade =>
               this._getResetOption(
-                host,
+                parent,
                 this.setting.buildings[upgrade.name],
                 locale,
                 settings,
                 upgrade.label,
-                upgrade.name === host.game.religion.religionUpgrades.at(-1)?.name,
+                upgrade.name === parent.host.game.religion.religionUpgrades.at(-1)?.name,
               ),
             ),
 
-          new HeaderListItem(host, host.engine.i18n("$religion.panel.cryptotheology.label")),
-          ...host.game.religion.transcendenceUpgrades
+          new HeaderListItem(
+            parent,
+            parent.host.engine.i18n("$religion.panel.cryptotheology.label"),
+          ),
+          ...parent.host.game.religion.transcendenceUpgrades
             .filter(item => !isNil(this.setting.buildings[item.name]))
             .map(upgrade =>
               this._getResetOption(
-                host,
+                parent,
                 this.setting.buildings[upgrade.name],
                 locale,
                 settings,
@@ -105,7 +111,7 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
   }
 
   private _getResetOption(
-    host: KittenScientists,
+    parent: UiComponent,
     option: SettingTrigger,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ResetReligionSettings,
@@ -113,13 +119,13 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
     delimiter = false,
     upgradeIndicator = false,
   ) {
-    const element = new SettingTriggerListItem(host, option, locale, label, {
+    const element = new SettingTriggerListItem(parent, option, locale, label, {
       delimiter,
       onCheck: () => {
-        host.engine.imessage("status.reset.check.enable", [label]);
+        parent.host.engine.imessage("status.reset.check.enable", [label]);
       },
       onUnCheck: () => {
-        host.engine.imessage("status.reset.check.disable", [label]);
+        parent.host.engine.imessage("status.reset.check.disable", [label]);
       },
       onRefresh: () => {
         element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -128,16 +134,16 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
       },
       onSetTrigger: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("ui.trigger.prompt.absolute"),
-          host.engine.i18n("ui.trigger.build.prompt", [
+          parent,
+          parent.host.engine.i18n("ui.trigger.prompt.absolute"),
+          parent.host.engine.i18n("ui.trigger.build.prompt", [
             label,
             option.trigger !== -1
-              ? host.renderAbsolute(option.trigger, locale.selected)
-              : host.engine.i18n("ui.trigger.inactive"),
+              ? parent.host.renderAbsolute(option.trigger, locale.selected)
+              : parent.host.engine.i18n("ui.trigger.inactive"),
           ]),
-          option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
-          host.engine.i18n("ui.trigger.reset.promptExplainer"),
+          option.trigger !== -1 ? parent.host.renderAbsolute(option.trigger) : "",
+          parent.host.engine.i18n("ui.trigger.reset.promptExplainer"),
         );
 
         if (value === undefined) {

--- a/source/ui/ResetReligionSettingsUi.ts
+++ b/source/ui/ResetReligionSettingsUi.ts
@@ -23,90 +23,81 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
   ) {
     const label = parent.host.engine.i18n("ui.faith");
     super(parent, label, settings, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Religion,
     });
+
+    this.addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
 
     const unicornsArray: Array<ZigguratUpgrade | "unicornPasture"> = [...UnicornItems];
 
     this.addChild(
-      new SettingsList(parent, {
-        children: [
-          new HeaderListItem(parent, parent.host.engine.i18n("$religion.panel.ziggurat.label")),
-          this._getResetOption(
-            parent,
-            this.setting.buildings.unicornPasture,
-            locale,
-            settings,
-            parent.host.engine.i18n("$buildings.unicornPasture.label"),
+      new SettingsList(this).addChildren([
+        new HeaderListItem(this, this.host.engine.i18n("$religion.panel.ziggurat.label")),
+        this._getResetOption(
+          this,
+          this.setting.buildings.unicornPasture,
+          locale,
+          settings,
+          this.host.engine.i18n("$buildings.unicornPasture.label"),
+        ),
+
+        ...this.host.game.religion.zigguratUpgrades
+          .filter(
+            item => unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
+          )
+          .map(zigguratUpgrade =>
+            this._getResetOption(
+              this,
+              this.setting.buildings[zigguratUpgrade.name],
+              locale,
+              settings,
+              zigguratUpgrade.label,
+            ),
+          ),
+        new Delimiter(this),
+
+        ...this.host.game.religion.zigguratUpgrades
+          .filter(
+            item => !unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
+          )
+          .map(upgrade =>
+            this._getResetOption(
+              this,
+              this.setting.buildings[upgrade.name],
+              locale,
+              settings,
+              upgrade.label,
+            ),
+          ),
+        new Delimiter(this),
+
+        new HeaderListItem(this, this.host.engine.i18n("$religion.panel.orderOfTheSun.label")),
+        ...this.host.game.religion.religionUpgrades
+          .filter(item => !isNil(this.setting.buildings[item.name]))
+          .map(upgrade =>
+            this._getResetOption(
+              this,
+              this.setting.buildings[upgrade.name],
+              locale,
+              settings,
+              upgrade.label,
+              upgrade.name === this.host.game.religion.religionUpgrades.at(-1)?.name,
+            ),
           ),
 
-          ...parent.host.game.religion.zigguratUpgrades
-            .filter(
-              item =>
-                unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
-            )
-            .map(zigguratUpgrade =>
-              this._getResetOption(
-                parent,
-                this.setting.buildings[zigguratUpgrade.name],
-                locale,
-                settings,
-                zigguratUpgrade.label,
-              ),
+        new HeaderListItem(this, this.host.engine.i18n("$religion.panel.cryptotheology.label")),
+        ...this.host.game.religion.transcendenceUpgrades
+          .filter(item => !isNil(this.setting.buildings[item.name]))
+          .map(upgrade =>
+            this._getResetOption(
+              this,
+              this.setting.buildings[upgrade.name],
+              locale,
+              settings,
+              upgrade.label,
             ),
-          new Delimiter(parent),
-
-          ...parent.host.game.religion.zigguratUpgrades
-            .filter(
-              item =>
-                !unicornsArray.includes(item.name) && !isNil(this.setting.buildings[item.name]),
-            )
-            .map(upgrade =>
-              this._getResetOption(
-                parent,
-                this.setting.buildings[upgrade.name],
-                locale,
-                settings,
-                upgrade.label,
-              ),
-            ),
-          new Delimiter(parent),
-
-          new HeaderListItem(
-            parent,
-            parent.host.engine.i18n("$religion.panel.orderOfTheSun.label"),
           ),
-          ...parent.host.game.religion.religionUpgrades
-            .filter(item => !isNil(this.setting.buildings[item.name]))
-            .map(upgrade =>
-              this._getResetOption(
-                parent,
-                this.setting.buildings[upgrade.name],
-                locale,
-                settings,
-                upgrade.label,
-                upgrade.name === parent.host.game.religion.religionUpgrades.at(-1)?.name,
-              ),
-            ),
-
-          new HeaderListItem(
-            parent,
-            parent.host.engine.i18n("$religion.panel.cryptotheology.label"),
-          ),
-          ...parent.host.game.religion.transcendenceUpgrades
-            .filter(item => !isNil(this.setting.buildings[item.name]))
-            .map(upgrade =>
-              this._getResetOption(
-                parent,
-                this.setting.buildings[upgrade.name],
-                locale,
-                settings,
-                upgrade.label,
-              ),
-            ),
-        ],
-      }),
+      ]),
     );
   }
 

--- a/source/ui/ResetReligionSettingsUi.ts
+++ b/source/ui/ResetReligionSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -127,8 +126,8 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
         element.triggerButton.ineffective =
           sectionSetting.enabled && option.enabled && option.trigger === -1;
       },
-      onSetTrigger: () => {
-        Dialog.prompt(
+      onSetTrigger: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.trigger.prompt.absolute"),
           host.engine.i18n("ui.trigger.build.prompt", [
@@ -139,24 +138,20 @@ export class ResetReligionSettingsUi extends IconSettingsPanel<ResetReligionSett
           ]),
           option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
           host.engine.i18n("ui.trigger.reset.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
+        if (value === undefined) {
+          return;
+        }
 
-            if (value === "" || value.startsWith("-")) {
-              option.trigger = -1;
-              option.enabled = false;
-              return;
-            }
+        if (value === "" || value.startsWith("-")) {
+          option.trigger = -1;
+          option.enabled = false;
+          return;
+        }
 
-            option.trigger = Number(value);
-          })
-          .then(() => {
-            element.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        option.trigger = Number(value);
+
+        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetResourcesSettingsUi.ts
+++ b/source/ui/ResetResourcesSettingsUi.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -46,8 +45,8 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
           element.triggerButton.ineffective =
             settings.enabled && option.enabled && option.trigger === -1;
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.float"),
             host.engine.i18n("ui.trigger.build.prompt", [
@@ -58,24 +57,21 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
             ]),
             option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
             host.engine.i18n("ui.trigger.reset.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                option.trigger = -1;
-                option.enabled = false;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              option.trigger = Number(value);
-            })
-            .then(() => {
-              element.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            option.trigger = -1;
+            option.enabled = false;
+            return;
+          }
+
+          option.trigger = Number(value);
+
+          element.refreshUi();
         },
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);

--- a/source/ui/ResetResourcesSettingsUi.ts
+++ b/source/ui/ResetResourcesSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResetResourcesSettings } from "../settings/ResetResourcesSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -11,20 +10,21 @@ import { IconSettingsPanel } from "./components/IconSettingsPanel.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetResourcesSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("ui.resources");
-    super(host, label, settings, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const label = parent.host.engine.i18n("ui.resources");
+    super(parent, label, settings, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Resources,
     });
 
-    const resources = host.game.resPool.resources;
+    const resources = parent.host.game.resPool.resources;
 
     const items = [];
     let lastLabel = resources[0].title;
@@ -33,12 +33,12 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
     )) {
       const option = this.setting.resources[resource.name];
 
-      const element = new SettingTriggerListItem(host, option, locale, ucfirst(resource.title), {
+      const element = new SettingTriggerListItem(parent, option, locale, ucfirst(resource.title), {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [resource.title]);
+          parent.host.engine.imessage("status.sub.enable", [resource.title]);
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [resource.title]);
+          parent.host.engine.imessage("status.sub.disable", [resource.title]);
         },
         onRefresh: () => {
           element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -47,16 +47,16 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.float"),
-            host.engine.i18n("ui.trigger.build.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.float"),
+            parent.host.engine.i18n("ui.trigger.build.prompt", [
               resource.title,
               option.trigger !== -1
-                ? host.renderAbsolute(option.trigger, locale.selected)
-                : host.engine.i18n("ui.trigger.inactive"),
+                ? parent.host.renderAbsolute(option.trigger, locale.selected)
+                : parent.host.engine.i18n("ui.trigger.inactive"),
             ]),
-            option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
-            host.engine.i18n("ui.trigger.reset.promptExplainer"),
+            option.trigger !== -1 ? parent.host.renderAbsolute(option.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.reset.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -74,7 +74,7 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);
 
-      if (host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== resource.title[0]) {
           element.element.addClass(stylesLabelListItem.splitter);
         }
@@ -85,6 +85,6 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
       lastLabel = resource.title;
     }
 
-    this.addChild(new SettingsList(host, { children: items }));
+    this.addChild(new SettingsList(parent, { children: items }));
   }
 }

--- a/source/ui/ResetResourcesSettingsUi.ts
+++ b/source/ui/ResetResourcesSettingsUi.ts
@@ -20,11 +20,12 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
   ) {
     const label = parent.host.engine.i18n("ui.resources");
     super(parent, label, settings, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Resources,
     });
 
-    const resources = parent.host.game.resPool.resources;
+    this.addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
+
+    const resources = this.host.game.resPool.resources;
 
     const items = [];
     let lastLabel = resources[0].title;
@@ -33,12 +34,12 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
     )) {
       const option = this.setting.resources[resource.name];
 
-      const element = new SettingTriggerListItem(parent, option, locale, ucfirst(resource.title), {
+      const element = new SettingTriggerListItem(this, option, locale, ucfirst(resource.title), {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [resource.title]);
+          this.host.engine.imessage("status.sub.enable", [resource.title]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [resource.title]);
+          this.host.engine.imessage("status.sub.disable", [resource.title]);
         },
         onRefresh: () => {
           element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -47,16 +48,16 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            parent,
-            parent.host.engine.i18n("ui.trigger.prompt.float"),
-            parent.host.engine.i18n("ui.trigger.build.prompt", [
+            this,
+            this.host.engine.i18n("ui.trigger.prompt.float"),
+            this.host.engine.i18n("ui.trigger.build.prompt", [
               resource.title,
               option.trigger !== -1
-                ? parent.host.renderAbsolute(option.trigger, locale.selected)
-                : parent.host.engine.i18n("ui.trigger.inactive"),
+                ? this.host.renderAbsolute(option.trigger, locale.selected)
+                : this.host.engine.i18n("ui.trigger.inactive"),
             ]),
-            option.trigger !== -1 ? parent.host.renderAbsolute(option.trigger) : "",
-            parent.host.engine.i18n("ui.trigger.reset.promptExplainer"),
+            option.trigger !== -1 ? this.host.renderAbsolute(option.trigger) : "",
+            this.host.engine.i18n("ui.trigger.reset.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -74,7 +75,7 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);
 
-      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (this.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== resource.title[0]) {
           element.element.addClass(stylesLabelListItem.splitter);
         }
@@ -85,6 +86,6 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
       lastLabel = resource.title;
     }
 
-    this.addChild(new SettingsList(parent, { children: items }));
+    this.addChild(new SettingsList(this).addChildren(items));
   }
 }

--- a/source/ui/ResetResourcesSettingsUi.ts
+++ b/source/ui/ResetResourcesSettingsUi.ts
@@ -70,8 +70,6 @@ export class ResetResourcesSettingsUi extends IconSettingsPanel<ResetResourcesSe
           }
 
           option.trigger = Number(value);
-
-          element.refreshUi();
         },
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);

--- a/source/ui/ResetSettingsUi.ts
+++ b/source/ui/ResetSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { ResetSettings } from "../settings/ResetSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import { ResetBonfireSettingsUi } from "./ResetBonfireSettingsUi.js";
@@ -13,6 +12,7 @@ import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
   private readonly _bonfireUi: ResetBonfireSettingsUi;
@@ -23,24 +23,24 @@ export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
   private readonly _upgradesUi: ResetUpgradesSettingsUi;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("option.time.reset");
+    const label = parent.host.engine.i18n("option.time.reset");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -48,16 +48,16 @@ export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
       options,
     );
 
-    const list = new SettingsList(host, {
+    const list = new SettingsList(parent, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
-    this._bonfireUi = new ResetBonfireSettingsUi(host, this.setting.bonfire, locale);
-    this._religionUi = new ResetReligionSettingsUi(host, this.setting.religion, locale);
-    this._resourcesUi = new ResetResourcesSettingsUi(host, this.setting.resources, locale);
-    this._spaceUi = new ResetSpaceSettingsUi(host, this.setting.space, locale);
-    this._timeUi = new ResetTimeSettingsUi(host, this.setting.time, locale);
-    this._upgradesUi = new ResetUpgradesSettingsUi(host, this.setting.upgrades, locale);
+    this._bonfireUi = new ResetBonfireSettingsUi(parent, this.setting.bonfire, locale);
+    this._religionUi = new ResetReligionSettingsUi(parent, this.setting.religion, locale);
+    this._resourcesUi = new ResetResourcesSettingsUi(parent, this.setting.resources, locale);
+    this._spaceUi = new ResetSpaceSettingsUi(parent, this.setting.space, locale);
+    this._timeUi = new ResetTimeSettingsUi(parent, this.setting.time, locale);
+    this._upgradesUi = new ResetUpgradesSettingsUi(parent, this.setting.upgrades, locale);
 
     list.addChildren([
       this._bonfireUi,

--- a/source/ui/ResetSettingsUi.ts
+++ b/source/ui/ResetSettingsUi.ts
@@ -8,12 +8,11 @@ import { ResetResourcesSettingsUi } from "./ResetResourcesSettingsUi.js";
 import { ResetSpaceSettingsUi } from "./ResetSpaceSettingsUi.js";
 import { ResetTimeSettingsUi } from "./ResetTimeSettingsUi.js";
 import { ResetUpgradesSettingsUi } from "./ResetUpgradesSettingsUi.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
   private readonly _bonfireUi: ResetBonfireSettingsUi;
@@ -27,7 +26,7 @@ export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
     host: KittenScientists,
     settings: ResetSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("option.time.reset");
     super(

--- a/source/ui/ResetSettingsUi.ts
+++ b/source/ui/ResetSettingsUi.ts
@@ -60,6 +60,6 @@ export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
       this._timeUi,
       this._upgradesUi,
     ]);
-    this.addChild(list);
+    this.addChildContent(list);
   }
 }

--- a/source/ui/ResetSettingsUi.ts
+++ b/source/ui/ResetSettingsUi.ts
@@ -9,9 +9,9 @@ import { ResetTimeSettingsUi } from "./ResetTimeSettingsUi.js";
 import { ResetUpgradesSettingsUi } from "./ResetUpgradesSettingsUi.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
@@ -26,38 +26,31 @@ export class ResetSettingsUi extends SettingsPanel<ResetSettings> {
     parent: UiComponent,
     settings: ResetSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("option.time.reset");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
-      }),
-      options,
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    const list = new SettingsList(parent, {
+    const list = new SettingsList(this, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
-    this._bonfireUi = new ResetBonfireSettingsUi(parent, this.setting.bonfire, locale);
-    this._religionUi = new ResetReligionSettingsUi(parent, this.setting.religion, locale);
-    this._resourcesUi = new ResetResourcesSettingsUi(parent, this.setting.resources, locale);
-    this._spaceUi = new ResetSpaceSettingsUi(parent, this.setting.space, locale);
-    this._timeUi = new ResetTimeSettingsUi(parent, this.setting.time, locale);
-    this._upgradesUi = new ResetUpgradesSettingsUi(parent, this.setting.upgrades, locale);
+    this._bonfireUi = new ResetBonfireSettingsUi(this, this.setting.bonfire, locale);
+    this._religionUi = new ResetReligionSettingsUi(this, this.setting.religion, locale);
+    this._resourcesUi = new ResetResourcesSettingsUi(this, this.setting.resources, locale);
+    this._spaceUi = new ResetSpaceSettingsUi(this, this.setting.space, locale);
+    this._timeUi = new ResetTimeSettingsUi(this, this.setting.time, locale);
+    this._upgradesUi = new ResetUpgradesSettingsUi(this, this.setting.upgrades, locale);
 
     list.addChildren([
       this._bonfireUi,

--- a/source/ui/ResetSpaceSettingsUi.ts
+++ b/source/ui/ResetSpaceSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResetSpaceSettings } from "../settings/ResetSpaceSettings.js";
 import type { SettingOptions, SettingTrigger } from "../settings/Settings.js";
@@ -12,30 +11,31 @@ import { IconSettingsPanel } from "./components/IconSettingsPanel.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetSpaceSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("ui.space");
-    super(host, label, settings, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const label = parent.host.engine.i18n("ui.space");
+    super(parent, label, settings, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Space,
     });
 
     this.addChild(
-      new SettingsList(host, {
-        children: host.game.space.planets
+      new SettingsList(parent, {
+        children: parent.host.game.space.planets
           .filter(plant => 0 < plant.buildings.length)
           .flatMap((planet, indexPlanet, arrayPlant) => [
-            new HeaderListItem(host, host.engine.labelForPlanet(planet.name)),
+            new HeaderListItem(parent, parent.host.engine.labelForPlanet(planet.name)),
             ...planet.buildings
               .filter(item => !isNil(this.setting.buildings[item.name]))
               .map((building, indexBuilding, arrayBuilding) =>
                 this._getResetOption(
-                  host,
+                  parent,
                   this.setting.buildings[building.name],
                   locale,
                   settings,
@@ -49,7 +49,7 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
   }
 
   private _getResetOption(
-    host: KittenScientists,
+    parent: UiComponent,
     option: SettingTrigger,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ResetSpaceSettings,
@@ -57,13 +57,13 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
     delimiter = false,
     upgradeIndicator = false,
   ) {
-    const element = new SettingTriggerListItem(host, option, locale, label, {
+    const element = new SettingTriggerListItem(parent, option, locale, label, {
       delimiter,
       onCheck: () => {
-        host.engine.imessage("status.reset.check.enable", [label]);
+        parent.host.engine.imessage("status.reset.check.enable", [label]);
       },
       onUnCheck: () => {
-        host.engine.imessage("status.reset.check.disable", [label]);
+        parent.host.engine.imessage("status.reset.check.disable", [label]);
       },
       onRefresh: () => {
         element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -72,16 +72,16 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
       },
       onSetTrigger: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("ui.trigger.prompt.absolute"),
-          host.engine.i18n("ui.trigger.build.prompt", [
+          parent,
+          parent.host.engine.i18n("ui.trigger.prompt.absolute"),
+          parent.host.engine.i18n("ui.trigger.build.prompt", [
             label,
             option.trigger !== -1
-              ? host.renderAbsolute(option.trigger, locale.selected)
-              : host.engine.i18n("ui.trigger.inactive"),
+              ? parent.host.renderAbsolute(option.trigger, locale.selected)
+              : parent.host.engine.i18n("ui.trigger.inactive"),
           ]),
-          option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
-          host.engine.i18n("ui.trigger.reset.promptExplainer"),
+          option.trigger !== -1 ? parent.host.renderAbsolute(option.trigger) : "",
+          parent.host.engine.i18n("ui.trigger.reset.promptExplainer"),
         );
 
         if (value === undefined) {

--- a/source/ui/ResetSpaceSettingsUi.ts
+++ b/source/ui/ResetSpaceSettingsUi.ts
@@ -95,8 +95,6 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
         }
 
         option.trigger = Number(value);
-
-        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetSpaceSettingsUi.ts
+++ b/source/ui/ResetSpaceSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -71,8 +70,8 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
         element.triggerButton.ineffective =
           sectionSetting.enabled && option.enabled && option.trigger === -1;
       },
-      onSetTrigger: () => {
-        Dialog.prompt(
+      onSetTrigger: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.trigger.prompt.absolute"),
           host.engine.i18n("ui.trigger.build.prompt", [
@@ -83,24 +82,21 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
           ]),
           option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
           host.engine.i18n("ui.trigger.reset.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              option.trigger = -1;
-              option.enabled = false;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            option.trigger = Number(value);
-          })
-          .then(() => {
-            element.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          option.trigger = -1;
+          option.enabled = false;
+          return;
+        }
+
+        option.trigger = Number(value);
+
+        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetSpaceSettingsUi.ts
+++ b/source/ui/ResetSpaceSettingsUi.ts
@@ -21,21 +21,22 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
   ) {
     const label = parent.host.engine.i18n("ui.space");
     super(parent, label, settings, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Space,
     });
 
+    this.addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
+
     this.addChild(
-      new SettingsList(parent, {
-        children: parent.host.game.space.planets
+      new SettingsList(this).addChildren(
+        this.host.game.space.planets
           .filter(plant => 0 < plant.buildings.length)
           .flatMap((planet, indexPlanet, arrayPlant) => [
-            new HeaderListItem(parent, parent.host.engine.labelForPlanet(planet.name)),
+            new HeaderListItem(this, this.host.engine.labelForPlanet(planet.name)),
             ...planet.buildings
               .filter(item => !isNil(this.setting.buildings[item.name]))
               .map((building, indexBuilding, arrayBuilding) =>
                 this._getResetOption(
-                  parent,
+                  this,
                   this.setting.buildings[building.name],
                   locale,
                   settings,
@@ -44,7 +45,7 @@ export class ResetSpaceSettingsUi extends IconSettingsPanel<ResetSpaceSettings> 
                 ),
               ),
           ]),
-      }),
+      ),
     );
   }
 

--- a/source/ui/ResetTimeSettingsUi.ts
+++ b/source/ui/ResetTimeSettingsUi.ts
@@ -22,41 +22,40 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
   ) {
     const label = parent.host.engine.i18n("ui.time");
     super(parent, label, settings, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Time,
     });
 
-    this.addChild(
-      new SettingsList(parent, {
-        children: [
-          new HeaderListItem(parent, parent.host.engine.i18n("$workshop.chronoforge.label")),
-          ...parent.host.game.time.chronoforgeUpgrades
-            .filter(item => !isNil(this.setting.buildings[item.name]))
-            .map(building =>
-              this._getResetOption(
-                parent,
-                this.setting.buildings[building.name],
-                locale,
-                settings,
-                building.label,
-                building.name === parent.host.game.time.chronoforgeUpgrades.at(-1)?.name,
-              ),
-            ),
+    this.addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
 
-          new HeaderListItem(parent, parent.host.engine.i18n("$science.voidSpace.label")),
-          ...parent.host.game.time.voidspaceUpgrades
-            .filter(item => item.name in this.setting.buildings)
-            .map(building =>
-              this._getResetOption(
-                parent,
-                this.setting.buildings[building.name as TimeItem],
-                locale,
-                settings,
-                building.label,
-              ),
+    this.addChild(
+      new SettingsList(this).addChildren([
+        new HeaderListItem(this, this.host.engine.i18n("$workshop.chronoforge.label")),
+        ...this.host.game.time.chronoforgeUpgrades
+          .filter(item => !isNil(this.setting.buildings[item.name]))
+          .map(building =>
+            this._getResetOption(
+              this,
+              this.setting.buildings[building.name],
+              locale,
+              settings,
+              building.label,
+              building.name === this.host.game.time.chronoforgeUpgrades.at(-1)?.name,
             ),
-        ],
-      }),
+          ),
+
+        new HeaderListItem(this, this.host.engine.i18n("$science.voidSpace.label")),
+        ...this.host.game.time.voidspaceUpgrades
+          .filter(item => item.name in this.setting.buildings)
+          .map(building =>
+            this._getResetOption(
+              this,
+              this.setting.buildings[building.name as TimeItem],
+              locale,
+              settings,
+              building.label,
+            ),
+          ),
+      ]),
     );
   }
 

--- a/source/ui/ResetTimeSettingsUi.ts
+++ b/source/ui/ResetTimeSettingsUi.ts
@@ -107,8 +107,6 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
         }
 
         option.trigger = Number(value);
-
-        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetTimeSettingsUi.ts
+++ b/source/ui/ResetTimeSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -83,8 +82,8 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
         element.triggerButton.ineffective =
           sectionSetting.enabled && option.enabled && option.trigger === -1;
       },
-      onSetTrigger: () => {
-        Dialog.prompt(
+      onSetTrigger: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.trigger.prompt.absolute"),
           host.engine.i18n("ui.trigger.build.prompt", [
@@ -95,24 +94,21 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
           ]),
           option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
           host.engine.i18n("ui.trigger.reset.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              option.trigger = -1;
-              option.enabled = false;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            option.trigger = Number(value);
-          })
-          .then(() => {
-            element.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          option.trigger = -1;
+          option.enabled = false;
+          return;
+        }
+
+        option.trigger = Number(value);
+
+        element.refreshUi();
       },
       upgradeIndicator,
     });

--- a/source/ui/ResetTimeSettingsUi.ts
+++ b/source/ui/ResetTimeSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResetTimeSettings } from "../settings/ResetTimeSettings.js";
 import type { SettingOptions, SettingTrigger } from "../settings/Settings.js";
@@ -13,42 +12,43 @@ import { IconSettingsPanel } from "./components/IconSettingsPanel.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetTimeSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("ui.time");
-    super(host, label, settings, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const label = parent.host.engine.i18n("ui.time");
+    super(parent, label, settings, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Time,
     });
 
     this.addChild(
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new HeaderListItem(host, host.engine.i18n("$workshop.chronoforge.label")),
-          ...host.game.time.chronoforgeUpgrades
+          new HeaderListItem(parent, parent.host.engine.i18n("$workshop.chronoforge.label")),
+          ...parent.host.game.time.chronoforgeUpgrades
             .filter(item => !isNil(this.setting.buildings[item.name]))
             .map(building =>
               this._getResetOption(
-                host,
+                parent,
                 this.setting.buildings[building.name],
                 locale,
                 settings,
                 building.label,
-                building.name === host.game.time.chronoforgeUpgrades.at(-1)?.name,
+                building.name === parent.host.game.time.chronoforgeUpgrades.at(-1)?.name,
               ),
             ),
 
-          new HeaderListItem(host, host.engine.i18n("$science.voidSpace.label")),
-          ...host.game.time.voidspaceUpgrades
+          new HeaderListItem(parent, parent.host.engine.i18n("$science.voidSpace.label")),
+          ...parent.host.game.time.voidspaceUpgrades
             .filter(item => item.name in this.setting.buildings)
             .map(building =>
               this._getResetOption(
-                host,
+                parent,
                 this.setting.buildings[building.name as TimeItem],
                 locale,
                 settings,
@@ -61,7 +61,7 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
   }
 
   private _getResetOption(
-    host: KittenScientists,
+    parent: UiComponent,
     option: SettingTrigger,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ResetTimeSettings,
@@ -69,13 +69,13 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
     delimiter = false,
     upgradeIndicator = false,
   ) {
-    const element = new SettingTriggerListItem(host, option, locale, label, {
+    const element = new SettingTriggerListItem(parent, option, locale, label, {
       delimiter,
       onCheck: () => {
-        host.engine.imessage("status.reset.check.enable", [label]);
+        parent.host.engine.imessage("status.reset.check.enable", [label]);
       },
       onUnCheck: () => {
-        host.engine.imessage("status.reset.check.disable", [label]);
+        parent.host.engine.imessage("status.reset.check.disable", [label]);
       },
       onRefresh: () => {
         element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -84,16 +84,16 @@ export class ResetTimeSettingsUi extends IconSettingsPanel<ResetTimeSettings> {
       },
       onSetTrigger: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("ui.trigger.prompt.absolute"),
-          host.engine.i18n("ui.trigger.build.prompt", [
+          parent,
+          parent.host.engine.i18n("ui.trigger.prompt.absolute"),
+          parent.host.engine.i18n("ui.trigger.build.prompt", [
             label,
             option.trigger !== -1
-              ? host.renderAbsolute(option.trigger, locale.selected)
-              : host.engine.i18n("ui.trigger.inactive"),
+              ? parent.host.renderAbsolute(option.trigger, locale.selected)
+              : parent.host.engine.i18n("ui.trigger.inactive"),
           ]),
-          option.trigger !== -1 ? host.renderAbsolute(option.trigger) : "",
-          host.engine.i18n("ui.trigger.reset.promptExplainer"),
+          option.trigger !== -1 ? parent.host.renderAbsolute(option.trigger) : "",
+          parent.host.engine.i18n("ui.trigger.reset.promptExplainer"),
         );
 
         if (value === undefined) {

--- a/source/ui/ResetUpgradesSettingsUi.ts
+++ b/source/ui/ResetUpgradesSettingsUi.ts
@@ -19,11 +19,12 @@ export class ResetUpgradesSettingsUi extends IconSettingsPanel<ResetUpgradeSetti
   ) {
     const label = parent.host.engine.i18n("ui.upgrades");
     super(parent, label, settings, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Workshop,
     });
 
-    const upgrades = parent.host.game.workshop.upgrades.filter(
+    this.addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
+
+    const upgrades = this.host.game.workshop.upgrades.filter(
       upgrade => !isNil(this.setting.upgrades[upgrade.name]),
     );
 
@@ -35,9 +36,9 @@ export class ResetUpgradesSettingsUi extends IconSettingsPanel<ResetUpgradeSetti
     )) {
       const option = this.setting.upgrades[upgrade.name];
 
-      const element = this._getResetOption(parent, option, upgrade.label);
+      const element = this._getResetOption(this, option, upgrade.label);
 
-      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (this.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== upgrade.label[0]) {
           if (!isNil(lastElement)) {
             lastElement.element.addClass(stylesDelimiter.delimiter);
@@ -52,7 +53,7 @@ export class ResetUpgradesSettingsUi extends IconSettingsPanel<ResetUpgradeSetti
       lastLabel = upgrade.label;
     }
 
-    this.addChild(new SettingsList(parent, { children: items }));
+    this.addChild(new SettingsList(this).addChildren(items));
   }
 
   private _getResetOption(

--- a/source/ui/ResetUpgradesSettingsUi.ts
+++ b/source/ui/ResetUpgradesSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResetUpgradeSettings } from "../settings/ResetUpgradeSettings.js";
 import type { Setting, SettingOptions } from "../settings/Settings.js";
@@ -10,20 +9,21 @@ import { IconSettingsPanel } from "./components/IconSettingsPanel.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ResetUpgradesSettingsUi extends IconSettingsPanel<ResetUpgradeSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResetUpgradeSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("ui.upgrades");
-    super(host, label, settings, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const label = parent.host.engine.i18n("ui.upgrades");
+    super(parent, label, settings, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       icon: Icons.Workshop,
     });
 
-    const upgrades = host.game.workshop.upgrades.filter(
+    const upgrades = parent.host.game.workshop.upgrades.filter(
       upgrade => !isNil(this.setting.upgrades[upgrade.name]),
     );
 
@@ -35,9 +35,9 @@ export class ResetUpgradesSettingsUi extends IconSettingsPanel<ResetUpgradeSetti
     )) {
       const option = this.setting.upgrades[upgrade.name];
 
-      const element = this._getResetOption(host, option, upgrade.label);
+      const element = this._getResetOption(parent, option, upgrade.label);
 
-      if (host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== upgrade.label[0]) {
           if (!isNil(lastElement)) {
             lastElement.element.addClass(stylesDelimiter.delimiter);
@@ -52,23 +52,23 @@ export class ResetUpgradesSettingsUi extends IconSettingsPanel<ResetUpgradeSetti
       lastLabel = upgrade.label;
     }
 
-    this.addChild(new SettingsList(host, { children: items }));
+    this.addChild(new SettingsList(parent, { children: items }));
   }
 
   private _getResetOption(
-    host: KittenScientists,
+    parent: UiComponent,
     option: Setting,
     label: string,
     delimiter = false,
     upgradeIndicator = false,
   ) {
-    return new SettingListItem(host, option, label, {
+    return new SettingListItem(parent, option, label, {
       delimiter,
       onCheck: () => {
-        host.engine.imessage("status.reset.check.enable", [label]);
+        parent.host.engine.imessage("status.reset.check.enable", [label]);
       },
       onUnCheck: () => {
-        host.engine.imessage("status.reset.check.disable", [label]);
+        parent.host.engine.imessage("status.reset.check.disable", [label]);
       },
       upgradeIndicator,
     });

--- a/source/ui/ResourcesSettingsUi.ts
+++ b/source/ui/ResourcesSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { ResourcesSettings, ResourcesSettingsItem } from "../settings/ResourcesSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -14,22 +13,23 @@ import { SettingListItem, type SettingListItemOptions } from "./components/Setti
 import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 import { ConsumeButton } from "./components/buttons/ConsumeButton.js";
 import { StockButton } from "./components/buttons/StockButton.js";
 
 export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ResourcesSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: SettingsPanelOptions<LabelListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.resources");
+    const label = parent.host.engine.i18n("ui.resources");
     super(
-      host,
+      parent,
       settings,
-      new LabelListItem(host, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new LabelListItem(parent, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.Resources,
       }),
@@ -50,8 +50,8 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
     ];
 
     this.addChild(
-      new SettingsList(host, {
-        children: host.game.resPool.resources
+      new SettingsList(parent, {
+        children: parent.host.game.resPool.resources
           .filter(
             item =>
               !ignoredResources.includes(item.name) && !isNil(this.setting.resources[item.name]),
@@ -60,7 +60,7 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
           .map(
             resource => [this.setting.resources[resource.name], ucfirst(resource.title)] as const,
           )
-          .map(([setting, title]) => this._makeResourceSetting(host, setting, locale, title)),
+          .map(([setting, title]) => this._makeResourceSetting(parent, setting, locale, title)),
       }),
     );
   }
@@ -74,23 +74,23 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
    * @returns A new option with stock and consume values.
    */
   private _makeResourceSetting(
-    host: KittenScientists,
+    parent: UiComponent,
     option: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     label: string,
   ) {
-    const element = new SettingListItem(host, option, label, {
-      childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+    const element = new SettingListItem(parent, option, label, {
+      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       onCheck: () => {
-        host.engine.imessage("status.resource.enable", [label]);
+        parent.host.engine.imessage("status.resource.enable", [label]);
       },
       onUnCheck: () => {
-        host.engine.imessage("status.resource.disable", [label]);
+        parent.host.engine.imessage("status.resource.disable", [label]);
       },
     });
 
     // How many items to stock.
-    const stockElement = new StockButton(host, option, locale, label, {
+    const stockElement = new StockButton(parent, option, locale, label, {
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
@@ -101,7 +101,7 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
     element.head.addChild(stockElement);
 
     // The consume rate for the resource.
-    const consumeElement = new ConsumeButton(host, option, locale, label, {
+    const consumeElement = new ConsumeButton(parent, option, locale, label, {
       border: false,
       classes: [stylesButton.lastHeadAction],
       onRefresh: () => {

--- a/source/ui/ResourcesSettingsUi.ts
+++ b/source/ui/ResourcesSettingsUi.ts
@@ -46,7 +46,7 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
       "zebras",
     ];
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this).addChildren(
         this.host.game.resPool.resources
           .filter(

--- a/source/ui/ResourcesSettingsUi.ts
+++ b/source/ui/ResourcesSettingsUi.ts
@@ -7,14 +7,13 @@ import type { SettingOptions } from "../settings/Settings.js";
 import { ucfirst } from "../tools/Format.js";
 import type { Resource } from "../types/index.js";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import { LabelListItem } from "./components/LabelListItem.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 import { ConsumeButton } from "./components/buttons/ConsumeButton.js";
 import { StockButton } from "./components/buttons/StockButton.js";
 
@@ -23,7 +22,7 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
     host: KittenScientists,
     settings: ResourcesSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<LabelListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.resources");
     super(

--- a/source/ui/ResourcesSettingsUi.ts
+++ b/source/ui/ResourcesSettingsUi.ts
@@ -9,10 +9,10 @@ import stylesButton from "./components/Button.module.css";
 import { Container } from "./components/Container.js";
 import { LabelListItem } from "./components/LabelListItem.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 import { ConsumeButton } from "./components/buttons/ConsumeButton.js";
 import { StockButton } from "./components/buttons/StockButton.js";
@@ -22,18 +22,15 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
     parent: UiComponent,
     settings: ResourcesSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: SettingsPanelOptions<LabelListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.resources");
     super(
       parent,
       settings,
       new LabelListItem(parent, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.Resources,
-      }),
-      options,
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
     const ignoredResources: Array<Resource> = [
@@ -50,8 +47,8 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
     ];
 
     this.addChild(
-      new SettingsList(parent, {
-        children: parent.host.game.resPool.resources
+      new SettingsList(this).addChildren(
+        this.host.game.resPool.resources
           .filter(
             item =>
               !ignoredResources.includes(item.name) && !isNil(this.setting.resources[item.name]),
@@ -60,8 +57,8 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
           .map(
             resource => [this.setting.resources[resource.name], ucfirst(resource.title)] as const,
           )
-          .map(([setting, title]) => this._makeResourceSetting(parent, setting, locale, title)),
-      }),
+          .map(([setting, title]) => this._makeResourceSetting(this, setting, locale, title)),
+      ),
     );
   }
 
@@ -80,14 +77,13 @@ export class ResourcesSettingsUi extends SettingsPanel<ResourcesSettings> {
     label: string,
   ) {
     const element = new SettingListItem(parent, option, label, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
       onCheck: () => {
         parent.host.engine.imessage("status.resource.enable", [label]);
       },
       onUnCheck: () => {
         parent.host.engine.imessage("status.resource.disable", [label]);
       },
-    });
+    }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]);
 
     // How many items to stock.
     const stockElement = new StockButton(parent, option, locale, label, {

--- a/source/ui/ScienceSettingsUi.ts
+++ b/source/ui/ScienceSettingsUi.ts
@@ -38,7 +38,7 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: _item => {
+        onRefresh: () => {
           this.expando.ineffective =
             settings.enabled &&
             !settings.policies.enabled &&

--- a/source/ui/ScienceSettingsUi.ts
+++ b/source/ui/ScienceSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import { PolicySettingsUi } from "./PolicySettingsUi.js";
@@ -9,6 +8,7 @@ import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
   private readonly _policiesUi: PolicySettingsUi;
@@ -16,24 +16,24 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
   private readonly _observeStars: SettingListItem;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: ScienceSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.upgrade");
+    const label = parent.host.engine.i18n("ui.upgrade");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -47,7 +47,7 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
       }),
     );
 
-    this._policiesUi = new PolicySettingsUi(host, settings.policies, locale, settings, {
+    this._policiesUi = new PolicySettingsUi(parent, settings.policies, locale, settings, {
       onCheck: () => {
         this.refreshUi();
       },
@@ -55,7 +55,7 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
         this.refreshUi();
       },
     });
-    this._techsUi = new TechSettingsUi(host, settings.techs, locale, settings, {
+    this._techsUi = new TechSettingsUi(parent, settings.techs, locale, settings, {
       onCheck: () => {
         this.refreshUi();
       },
@@ -65,22 +65,26 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
     });
 
     this._observeStars = new SettingListItem(
-      host,
+      parent,
       this.setting.observe,
-      host.engine.i18n("option.observe"),
+      parent.host.engine.i18n("option.observe"),
       {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [host.engine.i18n("option.observe")]);
+          parent.host.engine.imessage("status.sub.enable", [
+            parent.host.engine.i18n("option.observe"),
+          ]);
           this.refreshUi();
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [host.engine.i18n("option.observe")]);
+          parent.host.engine.imessage("status.sub.disable", [
+            parent.host.engine.i18n("option.observe"),
+          ]);
           this.refreshUi();
         },
       },
     );
 
-    const itemsList = new SettingsList(host, {
+    const itemsList = new SettingsList(parent, {
       hasDisableAll: false,
       hasEnableAll: false,
     });

--- a/source/ui/ScienceSettingsUi.ts
+++ b/source/ui/ScienceSettingsUi.ts
@@ -65,10 +65,12 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
       hasEnableAll: false,
     });
     itemsList.addChildren([this._techsUi, this._policiesUi, this._observeStars]);
-    this.addChild(itemsList);
+    this.addChildContent(itemsList);
   }
 
-  override refreshUi(): void {
+  refreshUi(): void {
+    super.refreshUi();
+
     if (this.setting.observe.enabled) {
       $("#observeButton").hide();
     } else {

--- a/source/ui/ScienceSettingsUi.ts
+++ b/source/ui/ScienceSettingsUi.ts
@@ -4,12 +4,11 @@ import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import { PolicySettingsUi } from "./PolicySettingsUi.js";
 import { TechSettingsUi } from "./TechSettingsUi.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
   private readonly _policiesUi: PolicySettingsUi;
@@ -20,7 +19,7 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
     host: KittenScientists,
     settings: ScienceSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade");
     super(

--- a/source/ui/ScienceSettingsUi.ts
+++ b/source/ui/ScienceSettingsUi.ts
@@ -5,9 +5,9 @@ import { PolicySettingsUi } from "./PolicySettingsUi.js";
 import { TechSettingsUi } from "./TechSettingsUi.js";
 import { Container } from "./components/Container.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
@@ -19,23 +19,17 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
     parent: UiComponent,
     settings: ScienceSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.upgrade");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.expando.ineffective =
@@ -44,47 +38,29 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
             !settings.techs.enabled &&
             !settings.observe.enabled;
         },
-      }),
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    this._policiesUi = new PolicySettingsUi(parent, settings.policies, locale, settings, {
-      onCheck: () => {
-        this.refreshUi();
-      },
-      onUnCheck: () => {
-        this.refreshUi();
-      },
-    });
-    this._techsUi = new TechSettingsUi(parent, settings.techs, locale, settings, {
-      onCheck: () => {
-        this.refreshUi();
-      },
-      onUnCheck: () => {
-        this.refreshUi();
-      },
-    });
+    this._policiesUi = new PolicySettingsUi(this, settings.policies, locale, settings);
+    this._techsUi = new TechSettingsUi(this, settings.techs, locale, settings);
 
     this._observeStars = new SettingListItem(
-      parent,
+      this,
       this.setting.observe,
-      parent.host.engine.i18n("option.observe"),
+      this.host.engine.i18n("option.observe"),
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.observe"),
-          ]);
-          this.refreshUi();
+          this.host.engine.imessage("status.sub.enable", [this.host.engine.i18n("option.observe")]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.observe"),
+          this.host.engine.imessage("status.sub.disable", [
+            this.host.engine.i18n("option.observe"),
           ]);
-          this.refreshUi();
         },
       },
     );
 
-    const itemsList = new SettingsList(parent, {
+    const itemsList = new SettingsList(this, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
@@ -93,8 +69,6 @@ export class ScienceSettingsUi extends SettingsPanel<ScienceSettings> {
   }
 
   override refreshUi(): void {
-    super.refreshUi();
-
     if (this.setting.observe.enabled) {
       $("#observeButton").hide();
     } else {

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -65,6 +65,7 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -93,6 +94,7 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
                     delimiter:
                       indexPlanet < arrayPlant.length - 1 &&
                       indexBuilding === arrayBuilding.length - 1,
+                    renderLabelTrigger: false,
                   },
                 ),
               ),

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -68,11 +68,11 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
       }),
     );
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this, {
         onReset: () => {
           this.setting.load({ buildings: new SpaceSettings().buildings });
-          this.refreshUi();
+          this.requestRefresh();
         },
       }).addChildren(
         this.host.game.space.planets
@@ -113,6 +113,6 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
       this.setting,
     );
     listAddition.addChild(this._missionsUi);
-    this.addChild(listAddition);
+    this.addChildContent(listAddition);
   }
 }

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -47,8 +46,8 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -59,23 +58,20 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
+
+          this.refreshUi();
         },
       }),
     );

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -40,8 +40,8 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import { SpaceSettings } from "../settings/SpaceSettings.js";
 import { BuildSectionTools } from "./BuildSectionTools.js";
@@ -11,28 +10,29 @@ import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTriggerListItem> {
   private readonly _missionsUi: MissionSettingsUi;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: SpaceSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.space");
+    const label = parent.host.engine.i18n("ui.space");
     super(
-      host,
+      parent,
       settings,
-      new SettingTriggerListItem(host, settings, locale, label, {
+      new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -40,24 +40,24 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger() {
-          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+          this.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
-              ? host.engine.i18n("ui.trigger.section.inactive")
-              : host.renderPercentage(settings.trigger, locale.selected, true),
+              ? parent.host.engine.i18n("ui.trigger.section.inactive")
+              : parent.host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.percentage"),
-            host.engine.i18n("ui.trigger.section.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+            parent.host.engine.i18n("ui.trigger.section.prompt", [
               label,
               settings.trigger !== -1
-                ? host.renderPercentage(settings.trigger, locale.selected, true)
-                : host.engine.i18n("ui.infinity"),
+                ? parent.host.renderPercentage(settings.trigger, locale.selected, true)
+                : parent.host.engine.i18n("ui.infinity"),
             ]),
-            settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
-            host.engine.i18n("ui.trigger.section.promptExplainer"),
+            settings.trigger !== -1 ? parent.host.renderPercentage(settings.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.section.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -69,22 +69,22 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
             return;
           }
 
-          settings.trigger = host.parsePercentage(value);
+          settings.trigger = parent.host.parsePercentage(value);
         },
       }),
     );
 
     this.addChild(
-      new SettingsList(host, {
-        children: host.game.space.planets
+      new SettingsList(parent, {
+        children: parent.host.game.space.planets
           .filter(planet => 0 < planet.buildings.length)
           .flatMap((planet, indexPlanet, arrayPlant) => [
-            new HeaderListItem(host, host.engine.labelForPlanet(planet.name)),
+            new HeaderListItem(parent, parent.host.engine.labelForPlanet(planet.name)),
             ...planet.buildings
               .filter(item => !isNil(this.setting.buildings[item.name]))
               .map((building, indexBuilding, arrayBuilding) =>
                 BuildSectionTools.getBuildOption(
-                  host,
+                  parent,
                   this.setting.buildings[building.name],
                   locale,
                   this.setting,
@@ -105,14 +105,14 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
       }),
     );
 
-    const listAddition = new SettingsList(host, {
+    const listAddition = new SettingsList(parent, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
-    listAddition.addChild(new HeaderListItem(host, host.engine.i18n("ui.additional")));
+    listAddition.addChild(new HeaderListItem(parent, parent.host.engine.i18n("ui.additional")));
 
     this._missionsUi = new MissionSettingsUi(
-      host,
+      parent,
       this.setting.unlockMissions,
       locale,
       this.setting,

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -70,8 +70,6 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
           }
 
           settings.trigger = host.parsePercentage(value);
-
-          this.refreshUi();
         },
       }),
     );

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -6,13 +6,12 @@ import type { SettingOptions } from "../settings/Settings.js";
 import { SpaceSettings } from "../settings/SpaceSettings.js";
 import { BuildSectionTools } from "./BuildSectionTools.js";
 import { MissionSettingsUi } from "./MissionSettingsUi.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
 import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTriggerListItem> {
   private readonly _missionsUi: MissionSettingsUi;
@@ -21,7 +20,7 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTrigger
     host: KittenScientists,
     settings: SpaceSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.space");
     super(

--- a/source/ui/SpaceSettingsUi.ts
+++ b/source/ui/SpaceSettingsUi.ts
@@ -14,7 +14,7 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class SpaceSettingsUi extends SettingsPanel<SpaceSettings> {
+export class SpaceSettingsUi extends SettingsPanel<SpaceSettings, SettingTriggerListItem> {
   private readonly _missionsUi: MissionSettingsUi;
 
   constructor(
@@ -38,9 +38,8 @@ export class SpaceSettingsUi extends SettingsPanel<SpaceSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger: item => {
           item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [

--- a/source/ui/StateManagementUi.ts
+++ b/source/ui/StateManagementUi.ts
@@ -1,4 +1,4 @@
-import { isNil, mustExist } from "@oliversalzburg/js-utils/data/nil.js";
+import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { type Locale, de, enUS, he, zhCN } from "date-fns/locale";
@@ -63,21 +63,20 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       parent,
       settings,
       new LabelListItem(parent, label, {
-        childrenHead: [
-          new Container(parent, {
-            classes: [stylesLabelListItem.fillSpace],
-          }),
-        ],
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.State,
-      }),
+      }).addChildrenHead([
+        new Container(parent, {
+          classes: [stylesLabelListItem.fillSpace],
+        }),
+      ]),
     );
 
-    this.gameList = new SettingsList(parent, {
+    this.gameList = new SettingsList(this, {
       hasEnableAll: false,
       hasDisableAll: false,
     });
-    this.stateList = new SettingsList(parent, {
+    this.stateList = new SettingsList(this, {
       hasEnableAll: false,
       hasDisableAll: false,
     });
@@ -92,85 +91,76 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
             : enUS;
 
     this.addChild(
-      new SettingsList(parent, {
-        children: [
-          new SettingListItem(
-            parent,
-            this.setting.noConfirm,
-            parent.host.engine.i18n("state.noConfirm"),
-          ),
-          new ListItem(parent, { children: [new Delimiter(parent)] }),
-
-          new HeaderListItem(parent, parent.host.engine.i18n("state.local")),
-          new ToolbarListItem(parent, [
-            new Button(parent, parent.host.engine.i18n("state.import"), Icons.Import, {
-              onClick: () => {
-                this.import();
-              },
-              title: parent.host.engine.i18n("state.importTitle"),
-            }),
-          ]),
-          new ListItem(parent, { children: [new Delimiter(parent)] }),
-
-          new HeaderListItem(parent, parent.host.engine.i18n("state.localStates")),
-          new ToolbarListItem(parent, [
-            new Button(parent, parent.host.engine.i18n("state.store"), Icons.SaveAs, {
-              onClick: () => {
-                this.storeState();
-              },
-              title: parent.host.engine.i18n("state.storeState"),
-            }),
-            new Button(parent, parent.host.engine.i18n("copy"), Icons.Copy, {
-              onClick: () => {
-                this.copyState().catch(redirectErrorsToConsole(console));
-                parent.host.engine.imessage("state.copied.stateCurrent");
-              },
-              title: parent.host.engine.i18n("state.copy.stateCurrent"),
-            }),
-            new Button(parent, parent.host.engine.i18n("state.new"), Icons.Draft, {
-              onClick: () => {
-                this.storeStateFactoryDefaults();
-                parent.host.engine.imessage("state.stored.state");
-              },
-              title: parent.host.engine.i18n("state.storeFactory"),
-            }),
-            new Button(parent, parent.host.engine.i18n("state.exportAll"), Icons.Sync, {
-              onClick: () => {
-                this.exportStateAll();
-              },
-              title: parent.host.engine.i18n("state.exportAllTitle"),
-            }),
-          ]),
-          new ListItem(parent, { children: [this.stateList] }),
-          new ListItem(parent, { children: [new Delimiter(parent)] }),
-
-          new HeaderListItem(parent, parent.host.engine.i18n("state.localGames")),
-          new ToolbarListItem(parent, [
-            new Button(parent, parent.host.engine.i18n("state.store"), Icons.SaveAs, {
-              onClick: () => {
-                this.storeGame();
-                parent.host.engine.imessage("state.stored.game");
-              },
-              title: parent.host.engine.i18n("state.storeGame"),
-            }),
-            new Button(parent, parent.host.engine.i18n("copy"), Icons.Copy, {
-              onClick: () => {
-                this.copyGame().catch(redirectErrorsToConsole(console));
-                parent.host.engine.imessage("state.copied.gameCurrent");
-              },
-              title: parent.host.engine.i18n("state.copy.gameCurrent"),
-            }),
-          ]),
-          new ListItem(parent, { children: [this.gameList] }),
-          new SettingListItem(
-            parent,
-            this.setting.compress,
-            parent.host.engine.i18n("state.compress"),
-          ),
-        ],
+      new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
-      }),
+      }).addChildren([
+        new SettingListItem(this, this.setting.noConfirm, this.host.engine.i18n("state.noConfirm")),
+        new ListItem(this).addChild(new Delimiter(this)),
+
+        new HeaderListItem(this, this.host.engine.i18n("state.local")),
+        new ToolbarListItem(this).addChildren([
+          new Button(this, this.host.engine.i18n("state.import"), Icons.Import, {
+            onClick: () => {
+              this.import();
+            },
+            title: this.host.engine.i18n("state.importTitle"),
+          }),
+        ]),
+        new ListItem(this).addChild(new Delimiter(this)),
+
+        new HeaderListItem(this, this.host.engine.i18n("state.localStates")),
+        new ToolbarListItem(this).addChildren([
+          new Button(this, this.host.engine.i18n("state.store"), Icons.SaveAs, {
+            onClick: () => {
+              this.storeState();
+            },
+            title: this.host.engine.i18n("state.storeState"),
+          }),
+          new Button(this, this.host.engine.i18n("copy"), Icons.Copy, {
+            onClick: () => {
+              this.copyState().catch(redirectErrorsToConsole(console));
+              this.host.engine.imessage("state.copied.stateCurrent");
+            },
+            title: this.host.engine.i18n("state.copy.stateCurrent"),
+          }),
+          new Button(this, this.host.engine.i18n("state.new"), Icons.Draft, {
+            onClick: () => {
+              this.storeStateFactoryDefaults();
+              this.host.engine.imessage("state.stored.state");
+            },
+            title: this.host.engine.i18n("state.storeFactory"),
+          }),
+          new Button(this, this.host.engine.i18n("state.exportAll"), Icons.Sync, {
+            onClick: () => {
+              this.exportStateAll();
+            },
+            title: this.host.engine.i18n("state.exportAllTitle"),
+          }),
+        ]),
+        new ListItem(this).addChild(this.stateList),
+        new ListItem(this).addChild(new Delimiter(this)),
+
+        new HeaderListItem(this, this.host.engine.i18n("state.localGames")),
+        new ToolbarListItem(this).addChildren([
+          new Button(this, this.host.engine.i18n("state.store"), Icons.SaveAs, {
+            onClick: () => {
+              this.storeGame();
+              this.host.engine.imessage("state.stored.game");
+            },
+            title: this.host.engine.i18n("state.storeGame"),
+          }),
+          new Button(this, this.host.engine.i18n("copy"), Icons.Copy, {
+            onClick: () => {
+              this.copyGame().catch(redirectErrorsToConsole(console));
+              this.host.engine.imessage("state.copied.gameCurrent");
+            },
+            title: this.host.engine.i18n("state.copy.gameCurrent"),
+          }),
+        ]),
+        new ListItem(this).addChild(this.gameList),
+        new SettingListItem(this, this.setting.compress, this.host.engine.i18n("state.compress")),
+      ]),
     );
 
     this._loadGames();
@@ -235,13 +225,11 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
   }
 
   refreshUi(): void {
-    super.refreshUi();
     this._refreshGameList();
     this._refreshStateList();
   }
 
   private _refreshGameList() {
-    const parent = mustExist(this.parent);
     this.gameList.removeChildren(this.gameList.children);
     this.gameList.addChildren(
       this.games
@@ -250,60 +238,55 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
             new Date(a.unwrap().timestamp).getTime() - new Date(b.unwrap().timestamp).getTime(),
         )
         .map(game => [game.unwrap(), game] as const)
-        .map(
-          ([game, gameSlot]) =>
-            new ButtonListItem(
-              parent,
-              new TextButton(
-                parent,
-                `${game.label} (${formatDistanceToNow(new Date(game.timestamp), {
-                  addSuffix: true,
-                  locale: this.locale,
-                })})`,
-                {
-                  onClick: () => {
-                    this.loadGame(game.game).catch(redirectErrorsToConsole(console));
-                    this.host.engine.imessage("state.loaded.game", [game.label]);
-                  },
-                  title: new Date(game.timestamp).toLocaleString(),
-                },
-              ),
+        .map(([game, gameSlot]) =>
+          new ButtonListItem(
+            this,
+            new TextButton(
+              this,
+              `${game.label} (${formatDistanceToNow(new Date(game.timestamp), {
+                addSuffix: true,
+                locale: this.locale,
+              })})`,
               {
-                children: [
-                  new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
-                  new IconButton(parent, Icons.Save, this.host.engine.i18n("state.update.game"), {
-                    onClick: () => {
-                      this.updateGame(gameSlot, this.host.game.save());
-                      this.host.engine.imessage("state.updated.game", [game.label]);
-                    },
-                  }),
-                  new IconButton(parent, Icons.Edit, this.host.engine.i18n("state.edit.game"), {
-                    onClick: () => {
-                      this.storeGame(game.game);
-                      this.deleteGame(gameSlot, true);
-                      this.host.engine.imessage("state.updated.game", [game.label]);
-                    },
-                  }),
-                  new IconButton(parent, Icons.Copy, this.host.engine.i18n("state.copy.game"), {
-                    onClick: () => {
-                      this.copyGame(game.game).catch(redirectErrorsToConsole(console));
-                      this.host.engine.imessage("state.copied.game", [game.label]);
-                    },
-                  }),
-                  new IconButton(parent, Icons.Delete, this.host.engine.i18n("state.delete.game"), {
-                    onClick: () => {
-                      this.deleteGame(gameSlot);
-                      this.host.engine.imessage("state.deleted.game", [game.label]);
-                    },
-                  }),
-                ],
+                onClick: () => {
+                  this.loadGame(game.game).catch(redirectErrorsToConsole(console));
+                  this.host.engine.imessage("state.loaded.game", [game.label]);
+                },
+                title: new Date(game.timestamp).toLocaleString(),
               },
             ),
+          ).addChildren([
+            new Container(this, { classes: [stylesLabelListItem.fillSpace] }),
+            new IconButton(this, Icons.Save, this.host.engine.i18n("state.update.game"), {
+              onClick: () => {
+                this.updateGame(gameSlot, this.host.game.save());
+                this.host.engine.imessage("state.updated.game", [game.label]);
+              },
+            }),
+            new IconButton(this, Icons.Edit, this.host.engine.i18n("state.edit.game"), {
+              onClick: () => {
+                this.storeGame(game.game);
+                this.deleteGame(gameSlot, true);
+                this.host.engine.imessage("state.updated.game", [game.label]);
+              },
+            }),
+            new IconButton(this, Icons.Copy, this.host.engine.i18n("state.copy.game"), {
+              onClick: () => {
+                this.copyGame(game.game).catch(redirectErrorsToConsole(console));
+                this.host.engine.imessage("state.copied.game", [game.label]);
+              },
+            }),
+            new IconButton(this, Icons.Delete, this.host.engine.i18n("state.delete.game"), {
+              onClick: () => {
+                this.deleteGame(gameSlot);
+                this.host.engine.imessage("state.deleted.game", [game.label]);
+              },
+            }),
+          ]),
         ),
     );
   }
   private _refreshStateList() {
-    const parent = mustExist(this.parent);
     this.stateList.removeChildren(this.stateList.children);
     this.stateList.addChildren(
       this.states
@@ -312,60 +295,51 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
             new Date(a.unwrap().timestamp).getTime() - new Date(b.unwrap().timestamp).getTime(),
         )
         .map(stateSlot => [stateSlot.unwrap(), stateSlot] as const)
-        .map(
-          ([state, stateSlot]) =>
-            new ButtonListItem(
-              parent,
-              new TextButton(
-                parent,
-                `${state.label} (${formatDistanceToNow(new Date(state.timestamp), {
-                  addSuffix: true,
-                  locale: this.locale,
-                })})`,
-                {
-                  onClick: () => {
-                    this.loadState(state.state);
-                    this.host.engine.imessage("state.loaded.state", [state.label]);
-                  },
-                  title: new Date(state.timestamp).toLocaleString(),
-                },
-              ),
+        .map(([state, stateSlot]) =>
+          new ButtonListItem(
+            this,
+            new TextButton(
+              this,
+              `${state.label} (${formatDistanceToNow(new Date(state.timestamp), {
+                addSuffix: true,
+                locale: this.locale,
+              })})`,
               {
-                children: [
-                  new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
-                  new IconButton(parent, Icons.Save, this.host.engine.i18n("state.update.state"), {
-                    onClick: () => {
-                      this.updateState(stateSlot, this.host.engine.stateSerialize());
-                      this.host.engine.imessage("state.updated.state", [state.label]);
-                    },
-                  }),
-                  new IconButton(parent, Icons.Edit, this.host.engine.i18n("state.edit.state"), {
-                    onClick: () => {
-                      this.storeState(state.state);
-                      this.deleteState(stateSlot, true);
-                      this.host.engine.imessage("state.updated.state", [state.label]);
-                    },
-                  }),
-                  new IconButton(parent, Icons.Copy, this.host.engine.i18n("state.copy.state"), {
-                    onClick: () => {
-                      this.copyState(state.state).catch(redirectErrorsToConsole(console));
-                      this.host.engine.imessage("state.copied.state", [state.label]);
-                    },
-                  }),
-                  new IconButton(
-                    parent,
-                    Icons.Delete,
-                    this.host.engine.i18n("state.delete.state"),
-                    {
-                      onClick: () => {
-                        this.deleteState(stateSlot);
-                        this.host.engine.imessage("state.deleted.state", [state.label]);
-                      },
-                    },
-                  ),
-                ],
+                onClick: () => {
+                  this.loadState(state.state);
+                  this.host.engine.imessage("state.loaded.state", [state.label]);
+                },
+                title: new Date(state.timestamp).toLocaleString(),
               },
             ),
+          ).addChildren([
+            new Container(this, { classes: [stylesLabelListItem.fillSpace] }),
+            new IconButton(this, Icons.Save, this.host.engine.i18n("state.update.state"), {
+              onClick: () => {
+                this.updateState(stateSlot, this.host.engine.stateSerialize());
+                this.host.engine.imessage("state.updated.state", [state.label]);
+              },
+            }),
+            new IconButton(this, Icons.Edit, this.host.engine.i18n("state.edit.state"), {
+              onClick: () => {
+                this.storeState(state.state);
+                this.deleteState(stateSlot, true);
+                this.host.engine.imessage("state.updated.state", [state.label]);
+              },
+            }),
+            new IconButton(this, Icons.Copy, this.host.engine.i18n("state.copy.state"), {
+              onClick: () => {
+                this.copyState(state.state).catch(redirectErrorsToConsole(console));
+                this.host.engine.imessage("state.copied.state", [state.label]);
+              },
+            }),
+            new IconButton(this, Icons.Delete, this.host.engine.i18n("state.delete.state"), {
+              onClick: () => {
+                this.deleteState(stateSlot);
+                this.host.engine.imessage("state.deleted.state", [state.label]);
+              },
+            }),
+          ]),
         ),
     );
   }

--- a/source/ui/StateManagementUi.ts
+++ b/source/ui/StateManagementUi.ts
@@ -518,7 +518,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     }
 
     this.host.engine.stateLoad(state, true);
-    this.host.refreshUi();
+    this.host.refreshEntireUserInterface();
   }
 
   loadAutoSave() {

--- a/source/ui/StateManagementUi.ts
+++ b/source/ui/StateManagementUi.ts
@@ -1,4 +1,4 @@
-import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
+import { isNil, mustExist } from "@oliversalzburg/js-utils/data/nil.js";
 import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { type Locale, de, enUS, he, zhCN } from "date-fns/locale";
@@ -26,6 +26,7 @@ import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 import { TextButton } from "./components/TextButton.js";
 import { ToolbarListItem } from "./components/ToolbarListItem.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export type StoredGame = {
   label: string;
@@ -53,17 +54,17 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
   readonly locale: Locale;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: StateSettings,
     locale: SettingOptions<SupportedLocale>,
   ) {
-    const label = host.engine.i18n("state.title");
+    const label = parent.host.engine.i18n("state.title");
     super(
-      host,
+      parent,
       settings,
-      new LabelListItem(host, label, {
+      new LabelListItem(parent, label, {
         childrenHead: [
-          new Container(host, {
+          new Container(parent, {
             classes: [stylesLabelListItem.fillSpace],
           }),
         ],
@@ -72,11 +73,11 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       }),
     );
 
-    this.gameList = new SettingsList(host, {
+    this.gameList = new SettingsList(parent, {
       hasEnableAll: false,
       hasDisableAll: false,
     });
-    this.stateList = new SettingsList(host, {
+    this.stateList = new SettingsList(parent, {
       hasEnableAll: false,
       hasDisableAll: false,
     });
@@ -91,73 +92,81 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
             : enUS;
 
     this.addChild(
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new SettingListItem(host, this.setting.noConfirm, host.engine.i18n("state.noConfirm")),
-          new ListItem(host, { children: [new Delimiter(host)] }),
+          new SettingListItem(
+            parent,
+            this.setting.noConfirm,
+            parent.host.engine.i18n("state.noConfirm"),
+          ),
+          new ListItem(parent, { children: [new Delimiter(parent)] }),
 
-          new HeaderListItem(host, host.engine.i18n("state.local")),
-          new ToolbarListItem(host, [
-            new Button(host, host.engine.i18n("state.import"), Icons.Import, {
+          new HeaderListItem(parent, parent.host.engine.i18n("state.local")),
+          new ToolbarListItem(parent, [
+            new Button(parent, parent.host.engine.i18n("state.import"), Icons.Import, {
               onClick: () => {
                 this.import();
               },
-              title: host.engine.i18n("state.importTitle"),
+              title: parent.host.engine.i18n("state.importTitle"),
             }),
           ]),
-          new ListItem(host, { children: [new Delimiter(host)] }),
+          new ListItem(parent, { children: [new Delimiter(parent)] }),
 
-          new HeaderListItem(host, host.engine.i18n("state.localStates")),
-          new ToolbarListItem(host, [
-            new Button(host, host.engine.i18n("state.store"), Icons.SaveAs, {
+          new HeaderListItem(parent, parent.host.engine.i18n("state.localStates")),
+          new ToolbarListItem(parent, [
+            new Button(parent, parent.host.engine.i18n("state.store"), Icons.SaveAs, {
               onClick: () => {
                 this.storeState();
               },
-              title: host.engine.i18n("state.storeState"),
+              title: parent.host.engine.i18n("state.storeState"),
             }),
-            new Button(host, host.engine.i18n("copy"), Icons.Copy, {
+            new Button(parent, parent.host.engine.i18n("copy"), Icons.Copy, {
               onClick: () => {
                 this.copyState().catch(redirectErrorsToConsole(console));
-                host.engine.imessage("state.copied.stateCurrent");
+                parent.host.engine.imessage("state.copied.stateCurrent");
               },
-              title: host.engine.i18n("state.copy.stateCurrent"),
+              title: parent.host.engine.i18n("state.copy.stateCurrent"),
             }),
-            new Button(host, host.engine.i18n("state.new"), Icons.Draft, {
+            new Button(parent, parent.host.engine.i18n("state.new"), Icons.Draft, {
               onClick: () => {
                 this.storeStateFactoryDefaults();
-                host.engine.imessage("state.stored.state");
+                parent.host.engine.imessage("state.stored.state");
               },
-              title: host.engine.i18n("state.storeFactory"),
+              title: parent.host.engine.i18n("state.storeFactory"),
             }),
-            new Button(host, host.engine.i18n("state.exportAll"), Icons.Sync, {
+            new Button(parent, parent.host.engine.i18n("state.exportAll"), Icons.Sync, {
               onClick: () => {
                 this.exportStateAll();
               },
-              title: host.engine.i18n("state.exportAllTitle"),
+              title: parent.host.engine.i18n("state.exportAllTitle"),
             }),
           ]),
-          new ListItem(host, { children: [this.stateList] }),
-          new ListItem(host, { children: [new Delimiter(host)] }),
+          new ListItem(parent, { children: [this.stateList] }),
+          new ListItem(parent, { children: [new Delimiter(parent)] }),
 
-          new HeaderListItem(host, host.engine.i18n("state.localGames")),
-          new ToolbarListItem(host, [
-            new Button(host, host.engine.i18n("state.store"), Icons.SaveAs, {
+          new HeaderListItem(parent, parent.host.engine.i18n("state.localGames")),
+          new ToolbarListItem(parent, [
+            new Button(parent, parent.host.engine.i18n("state.store"), Icons.SaveAs, {
               onClick: () => {
                 this.storeGame();
-                host.engine.imessage("state.stored.game");
+                parent.host.engine.imessage("state.stored.game");
               },
-              title: host.engine.i18n("state.storeGame"),
+              title: parent.host.engine.i18n("state.storeGame"),
             }),
-            new Button(host, host.engine.i18n("copy"), Icons.Copy, {
+            new Button(parent, parent.host.engine.i18n("copy"), Icons.Copy, {
               onClick: () => {
                 this.copyGame().catch(redirectErrorsToConsole(console));
-                host.engine.imessage("state.copied.gameCurrent");
+                parent.host.engine.imessage("state.copied.gameCurrent");
               },
-              title: host.engine.i18n("state.copy.gameCurrent"),
+              title: parent.host.engine.i18n("state.copy.gameCurrent"),
             }),
           ]),
-          new ListItem(host, { children: [this.gameList] }),
-          new SettingListItem(host, this.setting.compress, host.engine.i18n("state.compress")),
+          new ListItem(parent, { children: [this.gameList] }),
+          new SettingListItem(
+            parent,
+            this.setting.compress,
+            parent.host.engine.i18n("state.compress"),
+          ),
         ],
         hasDisableAll: false,
         hasEnableAll: false,
@@ -232,6 +241,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
   }
 
   private _refreshGameList() {
+    const parent = mustExist(this.parent);
     this.gameList.removeChildren(this.gameList.children);
     this.gameList.addChildren(
       this.games
@@ -243,9 +253,9 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
         .map(
           ([game, gameSlot]) =>
             new ButtonListItem(
-              this._host,
+              parent,
               new TextButton(
-                this._host,
+                parent,
                 `${game.label} (${formatDistanceToNow(new Date(game.timestamp), {
                   addSuffix: true,
                   locale: this.locale,
@@ -253,59 +263,39 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
                 {
                   onClick: () => {
                     this.loadGame(game.game).catch(redirectErrorsToConsole(console));
-                    this._host.engine.imessage("state.loaded.game", [game.label]);
+                    this.host.engine.imessage("state.loaded.game", [game.label]);
                   },
                   title: new Date(game.timestamp).toLocaleString(),
                 },
               ),
               {
                 children: [
-                  new Container(this._host, { classes: [stylesLabelListItem.fillSpace] }),
-                  new IconButton(
-                    this._host,
-                    Icons.Save,
-                    this._host.engine.i18n("state.update.game"),
-                    {
-                      onClick: () => {
-                        this.updateGame(gameSlot, this._host.game.save());
-                        this._host.engine.imessage("state.updated.game", [game.label]);
-                      },
+                  new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
+                  new IconButton(parent, Icons.Save, this.host.engine.i18n("state.update.game"), {
+                    onClick: () => {
+                      this.updateGame(gameSlot, this.host.game.save());
+                      this.host.engine.imessage("state.updated.game", [game.label]);
                     },
-                  ),
-                  new IconButton(
-                    this._host,
-                    Icons.Edit,
-                    this._host.engine.i18n("state.edit.game"),
-                    {
-                      onClick: () => {
-                        this.storeGame(game.game);
-                        this.deleteGame(gameSlot, true);
-                        this._host.engine.imessage("state.updated.game", [game.label]);
-                      },
+                  }),
+                  new IconButton(parent, Icons.Edit, this.host.engine.i18n("state.edit.game"), {
+                    onClick: () => {
+                      this.storeGame(game.game);
+                      this.deleteGame(gameSlot, true);
+                      this.host.engine.imessage("state.updated.game", [game.label]);
                     },
-                  ),
-                  new IconButton(
-                    this._host,
-                    Icons.Copy,
-                    this._host.engine.i18n("state.copy.game"),
-                    {
-                      onClick: () => {
-                        this.copyGame(game.game).catch(redirectErrorsToConsole(console));
-                        this._host.engine.imessage("state.copied.game", [game.label]);
-                      },
+                  }),
+                  new IconButton(parent, Icons.Copy, this.host.engine.i18n("state.copy.game"), {
+                    onClick: () => {
+                      this.copyGame(game.game).catch(redirectErrorsToConsole(console));
+                      this.host.engine.imessage("state.copied.game", [game.label]);
                     },
-                  ),
-                  new IconButton(
-                    this._host,
-                    Icons.Delete,
-                    this._host.engine.i18n("state.delete.game"),
-                    {
-                      onClick: () => {
-                        this.deleteGame(gameSlot);
-                        this._host.engine.imessage("state.deleted.game", [game.label]);
-                      },
+                  }),
+                  new IconButton(parent, Icons.Delete, this.host.engine.i18n("state.delete.game"), {
+                    onClick: () => {
+                      this.deleteGame(gameSlot);
+                      this.host.engine.imessage("state.deleted.game", [game.label]);
                     },
-                  ),
+                  }),
                 ],
               },
             ),
@@ -313,6 +303,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     );
   }
   private _refreshStateList() {
+    const parent = mustExist(this.parent);
     this.stateList.removeChildren(this.stateList.children);
     this.stateList.addChildren(
       this.states
@@ -324,9 +315,9 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
         .map(
           ([state, stateSlot]) =>
             new ButtonListItem(
-              this._host,
+              parent,
               new TextButton(
-                this._host,
+                parent,
                 `${state.label} (${formatDistanceToNow(new Date(state.timestamp), {
                   addSuffix: true,
                   locale: this.locale,
@@ -334,56 +325,41 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
                 {
                   onClick: () => {
                     this.loadState(state.state);
-                    this._host.engine.imessage("state.loaded.state", [state.label]);
+                    this.host.engine.imessage("state.loaded.state", [state.label]);
                   },
                   title: new Date(state.timestamp).toLocaleString(),
                 },
               ),
               {
                 children: [
-                  new Container(this._host, { classes: [stylesLabelListItem.fillSpace] }),
-                  new IconButton(
-                    this._host,
-                    Icons.Save,
-                    this._host.engine.i18n("state.update.state"),
-                    {
-                      onClick: () => {
-                        this.updateState(stateSlot, this._host.engine.stateSerialize());
-                        this._host.engine.imessage("state.updated.state", [state.label]);
-                      },
+                  new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
+                  new IconButton(parent, Icons.Save, this.host.engine.i18n("state.update.state"), {
+                    onClick: () => {
+                      this.updateState(stateSlot, this.host.engine.stateSerialize());
+                      this.host.engine.imessage("state.updated.state", [state.label]);
                     },
-                  ),
-                  new IconButton(
-                    this._host,
-                    Icons.Edit,
-                    this._host.engine.i18n("state.edit.state"),
-                    {
-                      onClick: () => {
-                        this.storeState(state.state);
-                        this.deleteState(stateSlot, true);
-                        this._host.engine.imessage("state.updated.state", [state.label]);
-                      },
+                  }),
+                  new IconButton(parent, Icons.Edit, this.host.engine.i18n("state.edit.state"), {
+                    onClick: () => {
+                      this.storeState(state.state);
+                      this.deleteState(stateSlot, true);
+                      this.host.engine.imessage("state.updated.state", [state.label]);
                     },
-                  ),
-                  new IconButton(
-                    this._host,
-                    Icons.Copy,
-                    this._host.engine.i18n("state.copy.state"),
-                    {
-                      onClick: () => {
-                        this.copyState(state.state).catch(redirectErrorsToConsole(console));
-                        this._host.engine.imessage("state.copied.state", [state.label]);
-                      },
+                  }),
+                  new IconButton(parent, Icons.Copy, this.host.engine.i18n("state.copy.state"), {
+                    onClick: () => {
+                      this.copyState(state.state).catch(redirectErrorsToConsole(console));
+                      this.host.engine.imessage("state.copied.state", [state.label]);
                     },
-                  ),
+                  }),
                   new IconButton(
-                    this._host,
+                    parent,
                     Icons.Delete,
-                    this._host.engine.i18n("state.delete.state"),
+                    this.host.engine.i18n("state.delete.state"),
                     {
                       onClick: () => {
                         this.deleteState(stateSlot);
-                        this._host.engine.imessage("state.deleted.state", [state.label]);
+                        this.host.engine.imessage("state.deleted.state", [state.label]);
                       },
                     },
                   ),
@@ -395,21 +371,21 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
   }
 
   async copyState(state?: EngineState) {
-    await this._host.copySettings(state, false);
+    await this.host.copySettings(state, false);
   }
 
   async copyGame(game?: KGSaveData) {
-    const saveData = game ?? this._host.game.save();
+    const saveData = game ?? this.host.game.save();
     const saveDataString = JSON.stringify(saveData);
     const encodedData = this.setting.compress.enabled
-      ? this._host.game.compressLZData(saveDataString)
+      ? this.host.game.compressLZData(saveDataString)
       : saveDataString;
 
     await window.navigator.clipboard.writeText(encodedData);
   }
 
   import() {
-    const input = window.prompt(this._host.engine.i18n("state.loadPrompt"));
+    const input = window.prompt(this.host.engine.i18n("state.loadPrompt"));
     if (isNil(input)) {
       return;
     }
@@ -418,7 +394,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       // decodeSettings throws if the input is not a valid engine state.
       const state = KittenScientists.decodeSettings(input);
       this.storeState(state);
-      this._host.engine.imessage("state.imported.state");
+      this.host.engine.imessage("state.imported.state");
       return;
     } catch (_error) {
       // Not a valid Kitten Scientists state.
@@ -430,7 +406,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       subjectData = JSON.parse(input) as KGSaveData;
     } catch (_error) {
       /* expected, as we assume compressed input */
-      const uncompressed = this._host.game.decompressLZData(input);
+      const uncompressed = this.host.game.decompressLZData(input);
       subjectData = JSON.parse(uncompressed) as KGSaveData;
     }
 
@@ -439,19 +415,19 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     if ("ks" in subjectData && !isNil(subjectData.ks)) {
       const state = subjectData.ks.state[0];
       stateLabel = this.storeState(state) ?? undefined;
-      this._host.engine.imessage("state.imported.state");
+      this.host.engine.imessage("state.imported.state");
       subjectData.ks = undefined;
     }
 
     this.storeGame(subjectData, stateLabel);
-    this._host.engine.imessage("state.imported.game");
+    this.host.engine.imessage("state.imported.game");
   }
 
   storeGame(game?: KGSaveData, label?: string): string | null {
     let gameLabel = label;
 
     if (isNil(gameLabel)) {
-      gameLabel = window.prompt(this._host.engine.i18n("state.storeGame.prompt")) ?? undefined;
+      gameLabel = window.prompt(this.host.engine.i18n("state.storeGame.prompt")) ?? undefined;
     }
 
     if (isNil(gameLabel)) {
@@ -460,7 +436,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
 
     // Normalize empty string to "no label".
     gameLabel =
-      (gameLabel === "" ? undefined : gameLabel) ?? this._host.engine.i18n("state.unlabeledGame");
+      (gameLabel === "" ? undefined : gameLabel) ?? this.host.engine.i18n("state.unlabeledGame");
 
     // Ensure labels aren't excessively long.
     gameLabel = gameLabel.substring(0, 127);
@@ -468,7 +444,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     this.games.push(
       new Unique({
         label: gameLabel,
-        game: game ?? this._host.game.save(),
+        game: game ?? this.host.game.save(),
         timestamp: new Date().toISOString(),
       }),
     );
@@ -483,7 +459,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     let stateLabel = label;
 
     if (isNil(stateLabel)) {
-      stateLabel = window.prompt(this._host.engine.i18n("state.storeState.prompt")) ?? undefined;
+      stateLabel = window.prompt(this.host.engine.i18n("state.storeState.prompt")) ?? undefined;
     }
 
     if (isNil(stateLabel)) {
@@ -492,8 +468,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
 
     // Normalize empty string to "no label".
     stateLabel =
-      (stateLabel === "" ? undefined : stateLabel) ??
-      this._host.engine.i18n("state.unlabeledState");
+      (stateLabel === "" ? undefined : stateLabel) ?? this.host.engine.i18n("state.unlabeledState");
 
     // Ensure labels aren't excessively long.
     stateLabel = stateLabel.substring(0, 127);
@@ -501,7 +476,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     this.states.push(
       new Unique({
         label: stateLabel,
-        state: state ?? this._host.engine.stateSerialize(),
+        state: state ?? this.host.engine.stateSerialize(),
         timestamp: new Date().toISOString(),
       }),
     );
@@ -558,7 +533,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       return;
     }
 
-    await new SavegameLoader(this._host.game).loadRaw(game);
+    await new SavegameLoader(this.host.game).loadRaw(game);
   }
 
   loadState(state: EngineState) {
@@ -566,12 +541,12 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       return;
     }
 
-    this._host.engine.stateLoad(state, true);
-    this._host.refreshUi();
+    this.host.engine.stateLoad(state, true);
+    this.host.refreshUi();
   }
 
   loadAutoSave() {
-    if (this._host.engine.isLoaded) {
+    if (this.host.engine.isLoaded) {
       console.info(...cl("Not attempting to load Auto-Save, because a state is already loaded."));
       return;
     }
@@ -583,7 +558,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     }
 
     console.info(...cl("Loading Auto-Save..."));
-    this._host.engine.stateLoad(existing.unwrap().state, false);
+    this.host.engine.stateLoad(existing.unwrap().state, false);
   }
 
   updateGame(game: Unique<StoredGame>, newGame: KGSaveData) {
@@ -649,7 +624,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
   private _destructiveActionPrevented(): boolean {
     if (
       !this.setting.noConfirm.enabled &&
-      !window.confirm(this._host.engine.i18n("state.confirmDestruction"))
+      !window.confirm(this.host.engine.i18n("state.confirmDestruction"))
     ) {
       return true;
     }

--- a/source/ui/StateManagementUi.ts
+++ b/source/ui/StateManagementUi.ts
@@ -90,7 +90,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
             ? de
             : enUS;
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
@@ -225,6 +225,8 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
   }
 
   refreshUi(): void {
+    super.refreshUi();
+
     this._refreshGameList();
     this._refreshStateList();
   }
@@ -424,7 +426,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     );
 
     this._storeGames();
-    this.refreshUi();
+    this.requestRefresh();
 
     return gameLabel;
   }
@@ -456,7 +458,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
     );
 
     this._storeStates();
-    this.refreshUi();
+    this.requestRefresh();
 
     return stateLabel;
   }
@@ -476,7 +478,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       });
 
       this._storeStates();
-      this.refreshUi();
+      this.requestRefresh();
 
       return;
     }
@@ -547,7 +549,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       timestamp: new Date().toISOString(),
     });
     this._storeGames();
-    this.refreshUi();
+    this.requestRefresh();
   }
 
   updateState(state: Unique<StoredState>, newState: EngineState) {
@@ -562,7 +564,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
       timestamp: new Date().toISOString(),
     });
     this._storeStates();
-    this.refreshUi();
+    this.requestRefresh();
   }
 
   deleteGame(game: Unique<StoredGame>, force = false) {
@@ -577,7 +579,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
 
     this.games.splice(index, 1);
     this._storeGames();
-    this.refreshUi();
+    this.requestRefresh();
   }
 
   deleteState(state: Unique<StoredState>, force = false) {
@@ -592,7 +594,7 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
 
     this.states.splice(index, 1);
     this._storeStates();
-    this.refreshUi();
+    this.requestRefresh();
   }
 
   private _destructiveActionPrevented(): boolean {

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TechSettings } from "../settings/TechSettings.js";
@@ -11,27 +10,28 @@ import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerListItem> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: TechSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ScienceSettings,
     options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.upgrade.techs");
+    const label = parent.host.engine.i18n("ui.upgrade.techs");
     super(
-      host,
+      parent,
       settings,
-      new SettingTriggerListItem(host, settings, locale, label, {
+      new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -49,24 +49,24 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             !Object.values(settings.techs).some(tech => tech.enabled);
         },
         onRefreshTrigger() {
-          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+          this.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger", [
             settings.trigger < 0
-              ? host.engine.i18n("ui.trigger.section.inactive")
-              : host.renderPercentage(settings.trigger, locale.selected, true),
+              ? parent.host.engine.i18n("ui.trigger.section.inactive")
+              : parent.host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.percentage"),
-            host.engine.i18n("ui.trigger.section.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+            parent.host.engine.i18n("ui.trigger.section.prompt", [
               label,
               settings.trigger !== -1
-                ? host.renderPercentage(settings.trigger, locale.selected, true)
-                : host.engine.i18n("ui.infinity"),
+                ? parent.host.renderPercentage(settings.trigger, locale.selected, true)
+                : parent.host.engine.i18n("ui.infinity"),
             ]),
-            settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
-            host.engine.i18n("ui.trigger.section.promptExplainer"),
+            settings.trigger !== -1 ? parent.host.renderPercentage(settings.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.section.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -78,26 +78,28 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             return;
           }
 
-          settings.trigger = host.parsePercentage(value);
+          settings.trigger = parent.host.parsePercentage(value);
         },
       }),
       options,
     );
 
-    const techs = host.game.science.techs.filter(tech => !isNil(this.setting.techs[tech.name]));
+    const techs = parent.host.game.science.techs.filter(
+      tech => !isNil(this.setting.techs[tech.name]),
+    );
 
     const items = [];
     let lastLabel = techs[0].label;
     for (const tech of techs.sort((a, b) => a.label.localeCompare(b.label, locale.selected))) {
       const option = this.setting.techs[tech.name];
 
-      const element = new SettingTriggerListItem(host, option, locale, tech.label, {
+      const element = new SettingTriggerListItem(parent, option, locale, tech.label, {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [tech.label]);
+          parent.host.engine.imessage("status.sub.enable", [tech.label]);
           this.refreshUi();
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [tech.label]);
+          parent.host.engine.imessage("status.sub.disable", [tech.label]);
           this.refreshUi();
         },
         onRefresh: () => {
@@ -110,26 +112,26 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             option.trigger === -1;
         },
         onRefreshTrigger: () => {
-          element.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+          element.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger", [
             option.trigger < 0
               ? settings.trigger < 0
-                ? host.engine.i18n("ui.trigger.section.blocked", [label])
-                : `${host.renderPercentage(settings.trigger, locale.selected, true)} (${host.engine.i18n("ui.trigger.section.inherited")})`
-              : host.renderPercentage(option.trigger, locale.selected, true),
+                ? parent.host.engine.i18n("ui.trigger.section.blocked", [label])
+                : `${parent.host.renderPercentage(settings.trigger, locale.selected, true)} (${parent.host.engine.i18n("ui.trigger.section.inherited")})`
+              : parent.host.renderPercentage(option.trigger, locale.selected, true),
           ]);
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.percentage"),
-            host.engine.i18n("ui.trigger.section.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+            parent.host.engine.i18n("ui.trigger.section.prompt", [
               label,
               option.trigger !== -1
-                ? host.renderPercentage(option.trigger, locale.selected, true)
-                : host.engine.i18n("ui.trigger.section.inherited"),
+                ? parent.host.renderPercentage(option.trigger, locale.selected, true)
+                : parent.host.engine.i18n("ui.trigger.section.inherited"),
             ]),
-            option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
-            host.engine.i18n("ui.trigger.section.promptExplainer"),
+            option.trigger !== -1 ? parent.host.renderPercentage(option.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.section.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -141,12 +143,12 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             return;
           }
 
-          option.trigger = host.parsePercentage(value);
+          option.trigger = parent.host.parsePercentage(value);
         },
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);
 
-      if (host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== tech.label[0]) {
           element.element.addClass(stylesLabelListItem.splitter);
         }
@@ -157,6 +159,6 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
       lastLabel = tech.label;
     }
 
-    this.addChild(new SettingsList(host, { children: items }));
+    this.addChild(new SettingsList(parent, { children: items }));
   }
 }

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -6,13 +6,12 @@ import type { ScienceSettings } from "../settings/ScienceSettings.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TechSettings } from "../settings/TechSettings.js";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerListItem> {
   constructor(
@@ -20,7 +19,7 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
     settings: TechSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ScienceSettings,
-    options?: PanelOptions & SettingListItemOptions,
+    options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade.techs");
     super(

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -49,8 +49,8 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             settings.enabled &&
             !Object.values(settings.techs).some(tech => tech.enabled);
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -150,6 +150,6 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
       lastLabel = tech.label;
     }
 
-    this.addChild(new SettingsList(this).addChildren(items));
+    this.addChildContent(new SettingsList(this).addChildren(items));
   }
 }

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { ScienceSettings } from "../settings/ScienceSettings.js";
@@ -56,8 +55,8 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -68,23 +67,18 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
         },
       }),
       options,
@@ -124,8 +118,8 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
               : host.renderPercentage(option.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -136,23 +130,18 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
             ]),
             option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                option.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              option.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            option.trigger = -1;
+            return;
+          }
+
+          option.trigger = host.parsePercentage(value);
         },
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -74,6 +74,7 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -136,6 +137,7 @@ export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerLi
 
           option.trigger = this.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);
 

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -14,13 +14,13 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class TechSettingsUi extends SettingsPanel<TechSettings> {
+export class TechSettingsUi extends SettingsPanel<TechSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: TechSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: ScienceSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: PanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade.techs");
     super(
@@ -37,11 +37,9 @@ export class TechSettingsUi extends SettingsPanel<TechSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          const element = item as SettingTriggerListItem;
-
-          element.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
-          element.triggerButton.ineffective =
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
+          this.settingItem.triggerButton.ineffective =
             sectionSetting.enabled &&
             settings.enabled &&
             settings.trigger === -1 &&

--- a/source/ui/TimeControlSettingsUi.ts
+++ b/source/ui/TimeControlSettingsUi.ts
@@ -7,10 +7,10 @@ import stylesButton from "./components/Button.module.css";
 import { Container } from "./components/Container.js";
 import { Dialog } from "./components/Dialog.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
@@ -24,43 +24,37 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
     parent: UiComponent,
     settings: TimeControlSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.timeCtrl");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
-      }),
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    const list = new SettingsList(parent, {
+    const list = new SettingsList(this, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
-    const accelerateLabel = parent.host.engine.i18n("option.accelerate");
+    const accelerateLabel = this.host.engine.i18n("option.accelerate");
     this._accelerateTime = new SettingTriggerListItem(
-      parent,
+      this,
       this.setting.accelerateTime,
       locale,
       accelerateLabel,
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [accelerateLabel]);
+          this.host.engine.imessage("status.sub.enable", [accelerateLabel]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [accelerateLabel]);
+          this.host.engine.imessage("status.sub.disable", [accelerateLabel]);
         },
         onRefresh: () => {
           this._accelerateTime.triggerButton.inactive = !this.setting.accelerateTime.enabled;
@@ -71,30 +65,30 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            parent,
-            parent.host.engine.i18n("ui.trigger.accelerateTime.prompt"),
-            parent.host.engine.i18n("ui.trigger.accelerateTime.promptTitle", [
-              parent.host.renderPercentage(
+            this,
+            this.host.engine.i18n("ui.trigger.accelerateTime.prompt"),
+            this.host.engine.i18n("ui.trigger.accelerateTime.promptTitle", [
+              this.host.renderPercentage(
                 this.setting.accelerateTime.trigger,
                 locale.selected,
                 true,
               ),
             ]),
-            parent.host.renderPercentage(this.setting.accelerateTime.trigger),
-            parent.host.engine.i18n("ui.trigger.accelerateTime.promptExplainer"),
+            this.host.renderPercentage(this.setting.accelerateTime.trigger),
+            this.host.engine.i18n("ui.trigger.accelerateTime.promptExplainer"),
           );
 
           if (value === undefined || value === "" || value.startsWith("-")) {
             return;
           }
 
-          this.setting.accelerateTime.trigger = parent.host.parsePercentage(value);
+          this.setting.accelerateTime.trigger = this.host.parsePercentage(value);
         },
       },
     );
     this._accelerateTime.triggerButton.element.addClass(stylesButton.lastHeadAction);
-    this._timeSkipUi = new TimeSkipSettingsUi(parent, this.setting.timeSkip, locale, settings);
-    this._resetUi = new ResetSettingsUi(parent, this.setting.reset, locale);
+    this._timeSkipUi = new TimeSkipSettingsUi(this, this.setting.timeSkip, locale, settings);
+    this._resetUi = new ResetSettingsUi(this, this.setting.reset, locale);
 
     this._items = [this._accelerateTime, this._timeSkipUi, this._resetUi];
 

--- a/source/ui/TimeControlSettingsUi.ts
+++ b/source/ui/TimeControlSettingsUi.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -70,8 +69,8 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
             this.setting.accelerateTime.enabled &&
             this.setting.accelerateTime.trigger === -1;
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.accelerateTime.prompt"),
             host.engine.i18n("ui.trigger.accelerateTime.promptTitle", [
@@ -79,18 +78,15 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
             ]),
             host.renderPercentage(this.setting.accelerateTime.trigger),
             host.engine.i18n("ui.trigger.accelerateTime.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined || value === "" || value.startsWith("-")) {
-                return;
-              }
+          );
 
-              this.setting.accelerateTime.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === undefined || value === "" || value.startsWith("-")) {
+            return;
+          }
+
+          this.setting.accelerateTime.trigger = host.parsePercentage(value);
+
+          this.refreshUi();
         },
       },
     );

--- a/source/ui/TimeControlSettingsUi.ts
+++ b/source/ui/TimeControlSettingsUi.ts
@@ -85,8 +85,6 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
           }
 
           this.setting.accelerateTime.trigger = host.parsePercentage(value);
-
-          this.refreshUi();
         },
       },
     );

--- a/source/ui/TimeControlSettingsUi.ts
+++ b/source/ui/TimeControlSettingsUi.ts
@@ -6,14 +6,13 @@ import type { TimeControlSettings } from "../settings/TimeControlSettings.js";
 import { ResetSettingsUi } from "./ResetSettingsUi.js";
 import { TimeSkipSettingsUi } from "./TimeSkipSettingsUi.js";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import { Dialog } from "./components/Dialog.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
   protected readonly _items: Array<SettingListItem>;
@@ -26,7 +25,7 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
     host: KittenScientists,
     settings: TimeControlSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.timeCtrl");
     super(

--- a/source/ui/TimeControlSettingsUi.ts
+++ b/source/ui/TimeControlSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TimeControlSettings } from "../settings/TimeControlSettings.js";
 import { ResetSettingsUi } from "./ResetSettingsUi.js";
@@ -12,6 +11,7 @@ import { SettingListItem, type SettingListItemOptions } from "./components/Setti
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
   protected readonly _items: Array<SettingListItem>;
@@ -21,46 +21,46 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
   private readonly _resetUi: ResetSettingsUi;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: TimeControlSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.timeCtrl");
+    const label = parent.host.engine.i18n("ui.timeCtrl");
     super(
-      host,
+      parent,
       settings,
-      new SettingListItem(host, settings, label, {
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+      new SettingListItem(parent, settings, label, {
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
       }),
     );
 
-    const list = new SettingsList(host, {
+    const list = new SettingsList(parent, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
-    const accelerateLabel = host.engine.i18n("option.accelerate");
+    const accelerateLabel = parent.host.engine.i18n("option.accelerate");
     this._accelerateTime = new SettingTriggerListItem(
-      host,
+      parent,
       this.setting.accelerateTime,
       locale,
       accelerateLabel,
       {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [accelerateLabel]);
+          parent.host.engine.imessage("status.sub.enable", [accelerateLabel]);
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [accelerateLabel]);
+          parent.host.engine.imessage("status.sub.disable", [accelerateLabel]);
         },
         onRefresh: () => {
           this._accelerateTime.triggerButton.inactive = !this.setting.accelerateTime.enabled;
@@ -71,26 +71,30 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.accelerateTime.prompt"),
-            host.engine.i18n("ui.trigger.accelerateTime.promptTitle", [
-              host.renderPercentage(this.setting.accelerateTime.trigger, locale.selected, true),
+            parent,
+            parent.host.engine.i18n("ui.trigger.accelerateTime.prompt"),
+            parent.host.engine.i18n("ui.trigger.accelerateTime.promptTitle", [
+              parent.host.renderPercentage(
+                this.setting.accelerateTime.trigger,
+                locale.selected,
+                true,
+              ),
             ]),
-            host.renderPercentage(this.setting.accelerateTime.trigger),
-            host.engine.i18n("ui.trigger.accelerateTime.promptExplainer"),
+            parent.host.renderPercentage(this.setting.accelerateTime.trigger),
+            parent.host.engine.i18n("ui.trigger.accelerateTime.promptExplainer"),
           );
 
           if (value === undefined || value === "" || value.startsWith("-")) {
             return;
           }
 
-          this.setting.accelerateTime.trigger = host.parsePercentage(value);
+          this.setting.accelerateTime.trigger = parent.host.parsePercentage(value);
         },
       },
     );
     this._accelerateTime.triggerButton.element.addClass(stylesButton.lastHeadAction);
-    this._timeSkipUi = new TimeSkipSettingsUi(host, this.setting.timeSkip, locale, settings);
-    this._resetUi = new ResetSettingsUi(host, this.setting.reset, locale);
+    this._timeSkipUi = new TimeSkipSettingsUi(parent, this.setting.timeSkip, locale, settings);
+    this._resetUi = new ResetSettingsUi(parent, this.setting.reset, locale);
 
     this._items = [this._accelerateTime, this._timeSkipUi, this._resetUi];
 

--- a/source/ui/TimeControlSettingsUi.ts
+++ b/source/ui/TimeControlSettingsUi.ts
@@ -93,6 +93,6 @@ export class TimeControlSettingsUi extends SettingsPanel<TimeControlSettings> {
     this._items = [this._accelerateTime, this._timeSkipUi, this._resetUi];
 
     list.addChildren(this._items);
-    this.addChild(list);
+    this.addChildContent(list);
   }
 }

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -66,7 +66,7 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
       }),
     );
 
-    this.addChildren([
+    this.addChildrenContent([
       new SettingsList(this).addChildren([
         new HeaderListItem(this, this.host.engine.i18n("$workshop.chronoforge.label")),
         ...this.host.game.time.chronoforgeUpgrades

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -68,8 +68,6 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
           }
 
           settings.trigger = host.parsePercentage(value);
-
-          this.refreshUi();
         },
       }),
     );

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -63,6 +63,7 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -81,6 +82,7 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
               label,
               {
                 delimiter: building.name === this.host.game.time.chronoforgeUpgrades.at(-1)?.name,
+                renderLabelTrigger: false,
               },
             ),
           ),
@@ -96,6 +98,7 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
               this.setting,
               building.label,
               label,
+              { renderLabelTrigger: false },
             ),
           ),
       ]),

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -13,12 +13,12 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class TimeSettingsUi extends SettingsPanel<TimeSettings> {
+export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: TimeSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: PanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.time");
     super(
@@ -35,9 +35,8 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger: item => {
           item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -45,8 +44,8 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -57,23 +56,20 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
+
+          this.refreshUi();
         },
       }),
     );

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -5,7 +5,7 @@ import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TimeItem, TimeSettings } from "../settings/TimeSettings.js";
 import { BuildSectionTools } from "./BuildSectionTools.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
+import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
@@ -18,7 +18,7 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
     host: KittenScientists,
     settings: TimeSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: PanelOptions & SettingListItemOptions,
+    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.time");
     super(

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -3,10 +3,9 @@ import type { SupportedLocale } from "../Engine.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TimeItem, TimeSettings } from "../settings/TimeSettings.js";
 import { BuildSectionTools } from "./BuildSectionTools.js";
-import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
@@ -17,7 +16,6 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
     parent: UiComponent,
     settings: TimeSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.time");
     super(
@@ -26,13 +24,9 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
       new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
@@ -73,66 +67,62 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
     );
 
     this.addChildren([
-      new SettingsList(parent, {
-        children: [
-          new HeaderListItem(parent, parent.host.engine.i18n("$workshop.chronoforge.label")),
-          ...parent.host.game.time.chronoforgeUpgrades
-            .filter(item => !isNil(this.setting.buildings[item.name]))
-            .map(building =>
-              BuildSectionTools.getBuildOption(
-                parent,
-                this.setting.buildings[building.name],
-                locale,
-                this.setting,
-                building.label,
-                label,
-                {
-                  delimiter:
-                    building.name === parent.host.game.time.chronoforgeUpgrades.at(-1)?.name,
-                },
-              ),
-            ),
-
-          new HeaderListItem(parent, parent.host.engine.i18n("$science.voidSpace.label")),
-          ...parent.host.game.time.voidspaceUpgrades
-            .filter(item => item.name in this.setting.buildings)
-            .map(building =>
-              BuildSectionTools.getBuildOption(
-                parent,
-                this.setting.buildings[building.name as TimeItem],
-                locale,
-                this.setting,
-                building.label,
-                label,
-              ),
-            ),
-        ],
-      }),
-
-      new SettingsList(parent, {
-        children: [
-          new HeaderListItem(parent, parent.host.engine.i18n("ui.additional")),
-          new SettingListItem(
-            parent,
-            this.setting.fixCryochambers,
-            parent.host.engine.i18n("option.fix.cry"),
-            {
-              onCheck: () => {
-                parent.host.engine.imessage("status.sub.enable", [
-                  parent.host.engine.i18n("option.fix.cry"),
-                ]);
+      new SettingsList(this).addChildren([
+        new HeaderListItem(this, this.host.engine.i18n("$workshop.chronoforge.label")),
+        ...this.host.game.time.chronoforgeUpgrades
+          .filter(item => !isNil(this.setting.buildings[item.name]))
+          .map(building =>
+            BuildSectionTools.getBuildOption(
+              this,
+              this.setting.buildings[building.name],
+              locale,
+              this.setting,
+              building.label,
+              label,
+              {
+                delimiter: building.name === this.host.game.time.chronoforgeUpgrades.at(-1)?.name,
               },
-              onUnCheck: () => {
-                parent.host.engine.imessage("status.sub.disable", [
-                  parent.host.engine.i18n("option.fix.cry"),
-                ]);
-              },
-            },
+            ),
           ),
-        ],
+
+        new HeaderListItem(this, this.host.engine.i18n("$science.voidSpace.label")),
+        ...this.host.game.time.voidspaceUpgrades
+          .filter(item => item.name in this.setting.buildings)
+          .map(building =>
+            BuildSectionTools.getBuildOption(
+              this,
+              this.setting.buildings[building.name as TimeItem],
+              locale,
+              this.setting,
+              building.label,
+              label,
+            ),
+          ),
+      ]),
+
+      new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
-      }),
+      }).addChildren([
+        new HeaderListItem(this, this.host.engine.i18n("ui.additional")),
+        new SettingListItem(
+          this,
+          this.setting.fixCryochambers,
+          this.host.engine.i18n("option.fix.cry"),
+          {
+            onCheck: () => {
+              this.host.engine.imessage("status.sub.enable", [
+                this.host.engine.i18n("option.fix.cry"),
+              ]);
+            },
+            onUnCheck: () => {
+              this.host.engine.imessage("status.sub.disable", [
+                this.host.engine.i18n("option.fix.cry"),
+              ]);
+            },
+          },
+        ),
+      ]),
     ]);
   }
 }

--- a/source/ui/TimeSettingsUi.ts
+++ b/source/ui/TimeSettingsUi.ts
@@ -38,8 +38,8 @@ export class TimeSettingsUi extends SettingsPanel<TimeSettings, SettingTriggerLi
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -79,8 +79,6 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
           }
 
           settings.trigger = host.parsePercentage(value);
-
-          this.refreshUi();
         },
       }),
       options,

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -64,8 +63,8 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
             this.head.elementLabel.removeClass(styles.active);
           }
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.activeHeatTransfer.prompt"),
             host.engine.i18n("ui.trigger.activeHeatTransfer.promptTitle", [
@@ -73,18 +72,15 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
             ]),
             host.renderPercentage(settings.trigger),
             host.engine.i18n("ui.trigger.activeHeatTransfer.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined || value === "" || value.startsWith("-")) {
-                return;
-              }
+          );
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === undefined || value === "" || value.startsWith("-")) {
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
+
+          this.refreshUi();
         },
       }),
       options,

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -10,7 +10,6 @@ import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { CyclesList } from "./components/CyclesList.js";
 import { Dialog } from "./components/Dialog.js";
 import type { SettingListItemOptions } from "./components/SettingListItem.js";
-import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
@@ -90,7 +89,6 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> 
 
     this.addChild(
       new SettingsList(host, {
-        classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         children: [
           new CyclesList(host, this.setting.cycles, {
             onCheck: (label: string) => {

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -76,7 +76,7 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
       }),
     );
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
@@ -84,11 +84,9 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
         new CyclesList(this, this.setting.cycles, {
           onCheckCycle: (label: string) => {
             this.host.engine.imessage("time.heatTransfer.cycle.enable", [label]);
-            this.refreshUi();
           },
           onUnCheckCycle: (label: string) => {
             this.host.engine.imessage("time.heatTransfer.cycle.disable", [label]);
-            this.refreshUi();
           },
         }),
       ]),

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TimeControlSettings } from "../settings/TimeControlSettings.js";
 import type { TimeSkipHeatSettings } from "../settings/TimeSkipHeatSettings.js";
@@ -12,31 +11,32 @@ import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class TimeSkipHeatSettingsUi extends SettingsPanel<
   TimeSkipHeatSettings,
   SettingTriggerListItem
 > {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: TimeSkipHeatSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TimeSkipSettings,
     sectionParentSetting: TimeControlSettings,
     options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("option.time.activeHeatTransfer");
+    const label = parent.host.engine.i18n("option.time.activeHeatTransfer");
     super(
-      host,
+      parent,
       settings,
-      new SettingTriggerListItem(host, settings, locale, label, {
+      new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           settings.activeHeatTransferStatus.enabled = false;
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
@@ -65,35 +65,35 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.activeHeatTransfer.prompt"),
-            host.engine.i18n("ui.trigger.activeHeatTransfer.promptTitle", [
-              host.renderPercentage(settings.trigger, locale.selected, true),
+            parent,
+            parent.host.engine.i18n("ui.trigger.activeHeatTransfer.prompt"),
+            parent.host.engine.i18n("ui.trigger.activeHeatTransfer.promptTitle", [
+              parent.host.renderPercentage(settings.trigger, locale.selected, true),
             ]),
-            host.renderPercentage(settings.trigger),
-            host.engine.i18n("ui.trigger.activeHeatTransfer.promptExplainer"),
+            parent.host.renderPercentage(settings.trigger),
+            parent.host.engine.i18n("ui.trigger.activeHeatTransfer.promptExplainer"),
           );
 
           if (value === undefined || value === "" || value.startsWith("-")) {
             return;
           }
 
-          settings.trigger = host.parsePercentage(value);
+          settings.trigger = parent.host.parsePercentage(value);
         },
       }),
       options,
     );
 
     this.addChild(
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
-          new CyclesList(host, this.setting.cycles, {
+          new CyclesList(parent, this.setting.cycles, {
             onCheckCycle: (label: string) => {
-              host.engine.imessage("time.heatTransfer.cycle.enable", [label]);
+              parent.host.engine.imessage("time.heatTransfer.cycle.enable", [label]);
               this.refreshUi();
             },
             onUnCheckCycle: (label: string) => {
-              host.engine.imessage("time.heatTransfer.cycle.disable", [label]);
+              parent.host.engine.imessage("time.heatTransfer.cycle.disable", [label]);
               this.refreshUi();
             },
           }),

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -14,14 +14,17 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> {
+export class TimeSkipHeatSettingsUi extends SettingsPanel<
+  TimeSkipHeatSettings,
+  SettingTriggerListItem
+> {
   constructor(
     host: KittenScientists,
     settings: TimeSkipHeatSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TimeSkipSettings,
     sectionParentSetting: TimeControlSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: PanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("option.time.activeHeatTransfer");
     super(
@@ -39,9 +42,9 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> 
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive = !settings.enabled;
-          (item as SettingTriggerListItem).triggerButton.ineffective =
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled;
+          this.settingItem.triggerButton.ineffective =
             sectionParentSetting.enabled &&
             sectionSetting.enabled &&
             settings.enabled &&
@@ -91,11 +94,11 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<TimeSkipHeatSettings> 
       new SettingsList(host, {
         children: [
           new CyclesList(host, this.setting.cycles, {
-            onCheck: (label: string) => {
+            onCheckCycle: (label: string) => {
               host.engine.imessage("time.heatTransfer.cycle.enable", [label]);
               this.refreshUi();
             },
-            onUnCheck: (label: string) => {
+            onUnCheckCycle: (label: string) => {
               host.engine.imessage("time.heatTransfer.cycle.disable", [label]);
               this.refreshUi();
             },

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -4,10 +4,8 @@ import type { TimeControlSettings } from "../settings/TimeControlSettings.js";
 import type { TimeSkipHeatSettings } from "../settings/TimeSkipHeatSettings.js";
 import type { TimeSkipSettings } from "../settings/TimeSkipSettings.js";
 import styles from "./TimeSkipHeatSettingsUi.module.css";
-import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { CyclesList } from "./components/CyclesList.js";
 import { Dialog } from "./components/Dialog.js";
-import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
@@ -23,7 +21,6 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TimeSkipSettings,
     sectionParentSetting: TimeControlSettings,
-    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("option.time.activeHeatTransfer");
     super(
@@ -32,14 +29,10 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
       new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
           settings.activeHeatTransferStatus.enabled = false;
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled;
@@ -81,26 +74,24 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
           settings.trigger = parent.host.parsePercentage(value);
         },
       }),
-      options,
     );
 
     this.addChild(
-      new SettingsList(parent, {
-        children: [
-          new CyclesList(parent, this.setting.cycles, {
-            onCheckCycle: (label: string) => {
-              parent.host.engine.imessage("time.heatTransfer.cycle.enable", [label]);
-              this.refreshUi();
-            },
-            onUnCheckCycle: (label: string) => {
-              parent.host.engine.imessage("time.heatTransfer.cycle.disable", [label]);
-              this.refreshUi();
-            },
-          }),
-        ],
+      new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,
-      }),
+      }).addChildren([
+        new CyclesList(this, this.setting.cycles, {
+          onCheckCycle: (label: string) => {
+            this.host.engine.imessage("time.heatTransfer.cycle.enable", [label]);
+            this.refreshUi();
+          },
+          onUnCheckCycle: (label: string) => {
+            this.host.engine.imessage("time.heatTransfer.cycle.disable", [label]);
+            this.refreshUi();
+          },
+        }),
+      ]),
     );
   }
 }

--- a/source/ui/TimeSkipHeatSettingsUi.ts
+++ b/source/ui/TimeSkipHeatSettingsUi.ts
@@ -6,7 +6,7 @@ import type { TimeControlSettings } from "../settings/TimeControlSettings.js";
 import type { TimeSkipHeatSettings } from "../settings/TimeSkipHeatSettings.js";
 import type { TimeSkipSettings } from "../settings/TimeSkipSettings.js";
 import styles from "./TimeSkipHeatSettingsUi.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
+import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { CyclesList } from "./components/CyclesList.js";
 import { Dialog } from "./components/Dialog.js";
 import type { SettingListItemOptions } from "./components/SettingListItem.js";
@@ -24,7 +24,7 @@ export class TimeSkipHeatSettingsUi extends SettingsPanel<
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TimeSkipSettings,
     sectionParentSetting: TimeControlSettings,
-    options?: PanelOptions & SettingListItemOptions,
+    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("option.time.activeHeatTransfer");
     super(

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -64,9 +64,9 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
             settings.enabled &&
             !Object.values(settings.seasons).some(season => season.enabled);
         },
-        onRefreshMax: item => {
-          item.maxButton.updateLabel(host.renderAbsolute(settings.max));
-          item.maxButton.element[0].title =
+        onRefreshMax() {
+          this.maxButton.updateLabel(host.renderAbsolute(settings.max));
+          this.maxButton.element[0].title =
             settings.max < 0
               ? host.engine.i18n("ui.max.timeSkip.titleInfinite", [label])
               : settings.max === 0
@@ -76,8 +76,8 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
                     label,
                   ]);
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : `${host.renderFloat(settings.trigger, locale.selected)} TC`,

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
@@ -83,8 +82,8 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
               : `${host.renderFloat(settings.trigger, locale.selected)} TC`,
           ]);
         },
-        onSetMax: () => {
-          Dialog.prompt(
+        onSetMax: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.max.timeSkip.prompt"),
             host.engine.i18n("ui.max.timeSkip.promptTitle", [
@@ -92,30 +91,25 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
             ]),
             host.renderAbsolute(settings.max),
             host.engine.i18n("ui.max.timeSkip.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.max = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              if (value === "0") {
-                settings.enabled = false;
-              }
+          if (value === "" || value.startsWith("-")) {
+            settings.max = -1;
+            return;
+          }
 
-              settings.max = host.parseAbsolute(value) ?? settings.max;
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "0") {
+            settings.enabled = false;
+          }
+
+          settings.max = host.parseAbsolute(value) ?? settings.max;
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.timeSkip.prompt"),
             host.engine.i18n("ui.trigger.timeSkip.promptTitle", [
@@ -123,18 +117,13 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
             ]),
             host.renderAbsolute(settings.trigger),
             host.engine.i18n("ui.trigger.timeSkip.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined || value === "" || value.startsWith("-")) {
-                return;
-              }
+          );
 
-              settings.trigger = host.parseAbsolute(value) ?? settings.trigger;
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === undefined || value === "" || value.startsWith("-")) {
+            return;
+          }
+
+          settings.trigger = host.parseAbsolute(value) ?? settings.trigger;
         },
       }),
       options,

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -120,6 +120,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
 
           settings.trigger = parent.host.parseAbsolute(value) ?? settings.trigger;
         },
+        renderLabelTrigger: false,
       }),
     );
     this.settingItem.triggerButton.element.removeClass(stylesButton.lastHeadAction);

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import { Icons } from "../images/Icons.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { TimeControlSettings } from "../settings/TimeControlSettings.js";
@@ -19,6 +18,7 @@ import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingMaxTriggerListItem } from "./components/SettingMaxTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingMaxTriggerListItem> {
   private readonly _cycles: CollapsiblePanel;
@@ -26,24 +26,24 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
   private readonly _activeHeatTransferUI: TimeSkipHeatSettingsUi;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: TimeSkipSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TimeControlSettings,
     options?: SettingsPanelOptions<SettingMaxTriggerListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("option.time.skip");
+    const label = parent.host.engine.i18n("option.time.skip");
     super(
-      host,
+      parent,
       settings,
-      new SettingMaxTriggerListItem(host, settings, locale, label, {
+      new SettingMaxTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -64,33 +64,33 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
             !Object.values(settings.seasons).some(season => season.enabled);
         },
         onRefreshMax() {
-          this.maxButton.updateLabel(host.renderAbsolute(settings.max));
+          this.maxButton.updateLabel(parent.host.renderAbsolute(settings.max));
           this.maxButton.element[0].title =
             settings.max < 0
-              ? host.engine.i18n("ui.max.timeSkip.titleInfinite", [label])
+              ? parent.host.engine.i18n("ui.max.timeSkip.titleInfinite", [label])
               : settings.max === 0
-                ? host.engine.i18n("ui.max.timeSkip.titleZero", [label])
-                : host.engine.i18n("ui.max.timeSkip.title", [
-                    host.renderAbsolute(settings.max),
+                ? parent.host.engine.i18n("ui.max.timeSkip.titleZero", [label])
+                : parent.host.engine.i18n("ui.max.timeSkip.title", [
+                    parent.host.renderAbsolute(settings.max),
                     label,
                   ]);
         },
         onRefreshTrigger() {
-          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+          this.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger", [
             settings.trigger < 0
-              ? host.engine.i18n("ui.trigger.section.inactive")
-              : `${host.renderFloat(settings.trigger, locale.selected)} TC`,
+              ? parent.host.engine.i18n("ui.trigger.section.inactive")
+              : `${parent.host.renderFloat(settings.trigger, locale.selected)} TC`,
           ]);
         },
         onSetMax: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.max.timeSkip.prompt"),
-            host.engine.i18n("ui.max.timeSkip.promptTitle", [
-              host.renderAbsolute(settings.max, locale.selected),
+            parent,
+            parent.host.engine.i18n("ui.max.timeSkip.prompt"),
+            parent.host.engine.i18n("ui.max.timeSkip.promptTitle", [
+              parent.host.renderAbsolute(settings.max, locale.selected),
             ]),
-            host.renderAbsolute(settings.max),
-            host.engine.i18n("ui.max.timeSkip.promptExplainer"),
+            parent.host.renderAbsolute(settings.max),
+            parent.host.engine.i18n("ui.max.timeSkip.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -106,24 +106,24 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
             settings.enabled = false;
           }
 
-          settings.max = host.parseAbsolute(value) ?? settings.max;
+          settings.max = parent.host.parseAbsolute(value) ?? settings.max;
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.timeSkip.prompt"),
-            host.engine.i18n("ui.trigger.timeSkip.promptTitle", [
-              host.renderAbsolute(settings.trigger, locale.selected),
+            parent,
+            parent.host.engine.i18n("ui.trigger.timeSkip.prompt"),
+            parent.host.engine.i18n("ui.trigger.timeSkip.promptTitle", [
+              parent.host.renderAbsolute(settings.trigger, locale.selected),
             ]),
-            host.renderAbsolute(settings.trigger),
-            host.engine.i18n("ui.trigger.timeSkip.promptExplainer"),
+            parent.host.renderAbsolute(settings.trigger),
+            parent.host.engine.i18n("ui.trigger.timeSkip.promptExplainer"),
           );
 
           if (value === undefined || value === "" || value.startsWith("-")) {
             return;
           }
 
-          settings.trigger = host.parseAbsolute(value) ?? settings.trigger;
+          settings.trigger = parent.host.parseAbsolute(value) ?? settings.trigger;
         },
       }),
       options,
@@ -131,21 +131,21 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
     this.settingItem.triggerButton.element.removeClass(stylesButton.lastHeadAction);
 
     this._cycles = new CollapsiblePanel(
-      host,
-      new LabelListItem(host, ucfirst(host.engine.i18n("ui.cycles")), {
+      parent,
+      new LabelListItem(parent, ucfirst(parent.host.engine.i18n("ui.cycles")), {
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         icon: Icons.Cycles,
       }),
       {
         children: [
-          new CyclesList(host, this.setting.cycles, {
+          new CyclesList(parent, this.setting.cycles, {
             onCheckCycle: (label: string) => {
-              host.engine.imessage("time.skip.cycle.enable", [label]);
+              parent.host.engine.imessage("time.skip.cycle.enable", [label]);
               this.refreshUi();
             },
             onUnCheckCycle: (label: string) => {
-              host.engine.imessage("time.skip.cycle.disable", [label]);
+              parent.host.engine.imessage("time.skip.cycle.disable", [label]);
               this.refreshUi();
             },
           }),
@@ -153,21 +153,21 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
       },
     );
     this._seasons = new CollapsiblePanel(
-      host,
-      new LabelListItem(host, ucfirst(host.engine.i18n("trade.seasons")), {
+      parent,
+      new LabelListItem(parent, ucfirst(parent.host.engine.i18n("trade.seasons")), {
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
-        childrenHead: [new Container(host, { classes: [stylesLabelListItem.fillSpace] })],
+        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         icon: Icons.Seasons,
       }),
       {
         children: [
-          new SeasonsList(host, this.setting.seasons, {
+          new SeasonsList(parent, this.setting.seasons, {
             onCheckSeason: (label: string) => {
-              host.engine.imessage("time.skip.season.enable", [label]);
+              parent.host.engine.imessage("time.skip.season.enable", [label]);
               this.refreshUi();
             },
             onUnCheckSeason: (label: string) => {
-              host.engine.imessage("time.skip.season.disable", [label]);
+              parent.host.engine.imessage("time.skip.season.disable", [label]);
               this.refreshUi();
             },
           }),
@@ -175,7 +175,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
       },
     );
     this._activeHeatTransferUI = new TimeSkipHeatSettingsUi(
-      host,
+      parent,
       this.setting.activeHeatTransfer,
       locale,
       settings,
@@ -183,14 +183,14 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
     );
 
     this.addChild(
-      new SettingsList(host, {
+      new SettingsList(parent, {
         children: [
           this._cycles,
           this._seasons,
           new SettingListItem(
-            host,
+            parent,
             this.setting.ignoreOverheat,
-            host.engine.i18n("option.time.skip.ignoreOverheat"),
+            parent.host.engine.i18n("option.time.skip.ignoreOverheat"),
           ),
           this._activeHeatTransferUI,
         ],

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -8,7 +8,7 @@ import type { TimeSkipSettings } from "../settings/TimeSkipSettings.js";
 import { ucfirst } from "../tools/Format.js";
 import { TimeSkipHeatSettingsUi } from "./TimeSkipHeatSettingsUi.js";
 import stylesButton from "./components/Button.module.css";
-import { CollapsiblePanel, type PanelOptions } from "./components/CollapsiblePanel.js";
+import { CollapsiblePanel } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import { CyclesList } from "./components/CyclesList.js";
 import { Dialog } from "./components/Dialog.js";
@@ -19,7 +19,7 @@ import { SettingListItem, type SettingListItemOptions } from "./components/Setti
 import stylesSettingListItem from "./components/SettingListItem.module.css";
 import { SettingMaxTriggerListItem } from "./components/SettingMaxTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingMaxTriggerListItem> {
   private readonly _cycles: CollapsiblePanel;
@@ -31,7 +31,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
     settings: TimeSkipSettings,
     locale: SettingOptions<SupportedLocale>,
     sectionSetting: TimeControlSettings,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingMaxTriggerListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("option.time.skip");
     super(

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -22,8 +22,8 @@ import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
 export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingMaxTriggerListItem> {
-  private readonly _cycles: CollapsiblePanel<PanelOptions<CyclesList>>;
-  private readonly _seasons: CollapsiblePanel<PanelOptions<SeasonsList>>;
+  private readonly _cycles: CollapsiblePanel;
+  private readonly _seasons: CollapsiblePanel;
   private readonly _activeHeatTransferUI: TimeSkipHeatSettingsUi;
 
   constructor(
@@ -48,13 +48,11 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          const element = item as SettingMaxTriggerListItem;
+        onRefresh: () => {
+          this.settingItem.maxButton.inactive = !settings.enabled || settings.max === -1;
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
 
-          element.maxButton.inactive = !settings.enabled || settings.max === -1;
-          element.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
-
-          element.maxButton.ineffective =
+          this.settingItem.maxButton.ineffective =
             sectionSetting.enabled && settings.enabled && settings.max === 0;
 
           this._cycles.expando.ineffective =
@@ -143,7 +141,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
     );
     this.settingItem.triggerButton.element.removeClass(stylesButton.lastHeadAction);
 
-    this._cycles = new CollapsiblePanel<PanelOptions<CyclesList>>(
+    this._cycles = new CollapsiblePanel(
       host,
       new LabelListItem(host, ucfirst(host.engine.i18n("ui.cycles")), {
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
@@ -153,11 +151,11 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
       {
         children: [
           new CyclesList(host, this.setting.cycles, {
-            onCheck: (label: string) => {
+            onCheckCycle: (label: string) => {
               host.engine.imessage("time.skip.cycle.enable", [label]);
               this.refreshUi();
             },
-            onUnCheck: (label: string) => {
+            onUnCheckCycle: (label: string) => {
               host.engine.imessage("time.skip.cycle.disable", [label]);
               this.refreshUi();
             },
@@ -165,7 +163,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
         ],
       },
     );
-    this._seasons = new CollapsiblePanel<PanelOptions<SeasonsList>>(
+    this._seasons = new CollapsiblePanel(
       host,
       new LabelListItem(host, ucfirst(host.engine.i18n("trade.seasons")), {
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
@@ -175,11 +173,11 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
       {
         children: [
           new SeasonsList(host, this.setting.seasons, {
-            onCheck: (label: string) => {
+            onCheckSeason: (label: string) => {
               host.engine.imessage("time.skip.season.enable", [label]);
               this.refreshUi();
             },
-            onUnCheck: (label: string) => {
+            onUnCheckSeason: (label: string) => {
               host.engine.imessage("time.skip.season.disable", [label]);
               this.refreshUi();
             },

--- a/source/ui/TimeSkipSettingsUi.ts
+++ b/source/ui/TimeSkipSettingsUi.ts
@@ -130,15 +130,13 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.Cycles,
       }).addChildrenHead([new Container(this, { classes: [stylesLabelListItem.fillSpace] })]),
-    ).addChildren([
+    ).addChildrenContent([
       new CyclesList(this, this.setting.cycles, {
         onCheckCycle: (label: string) => {
           this.host.engine.imessage("time.skip.cycle.enable", [label]);
-          this.refreshUi();
         },
         onUnCheckCycle: (label: string) => {
           this.host.engine.imessage("time.skip.cycle.disable", [label]);
-          this.refreshUi();
         },
       }),
     ]);
@@ -148,15 +146,13 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
         classes: [stylesSettingListItem.checked, stylesSettingListItem.setting],
         icon: Icons.Seasons,
       }).addChildrenHead([new Container(this, { classes: [stylesLabelListItem.fillSpace] })]),
-    ).addChildren([
+    ).addChildrenContent([
       new SeasonsList(this, this.setting.seasons, {
         onCheckSeason: (label: string) => {
           this.host.engine.imessage("time.skip.season.enable", [label]);
-          this.refreshUi();
         },
         onUnCheckSeason: (label: string) => {
           this.host.engine.imessage("time.skip.season.disable", [label]);
-          this.refreshUi();
         },
       }),
     ]);
@@ -168,7 +164,7 @@ export class TimeSkipSettingsUi extends SettingsPanel<TimeSkipSettings, SettingM
       sectionSetting,
     );
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,

--- a/source/ui/TradeSettingsUi.ts
+++ b/source/ui/TradeSettingsUi.ts
@@ -22,12 +22,12 @@ import { SettingsPanel } from "./components/SettingsPanel.js";
 import { BuyButton } from "./components/buttons-text/BuyButton.js";
 import { SellButton } from "./components/buttons-text/SellButton.js";
 
-export class TradeSettingsUi extends SettingsPanel<TradeSettings> {
+export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: TradeSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: PanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.trade");
     super(
@@ -44,9 +44,8 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger: item => {
           item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
@@ -133,8 +132,8 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings> {
             onUnCheck: () => {
               host.engine.imessage("status.sub.disable", [host.engine.i18n("option.crypto")]);
             },
-            onRefresh: item => {
-              (item as SettingTriggerListItem).triggerButton.inactive =
+            onRefresh: () => {
+              this.settingItem.triggerButton.inactive =
                 !this.setting.tradeBlackcoin.enabled || this.setting.tradeBlackcoin.trigger === -1;
             },
             onSetTrigger: () => {
@@ -280,11 +279,11 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings> {
     const panel = new SettingsPanel(host, option, element);
 
     const seasons = new SeasonsList(host, option.seasons, {
-      onCheck: (label: string) => {
+      onCheckSeason: (label: string) => {
         host.engine.imessage("trade.season.enable", [ucfirst(label), label]);
         element.refreshUi();
       },
-      onUnCheck: (label: string) => {
+      onUnCheckSeason: (label: string) => {
         host.engine.imessage("trade.season.disable", [ucfirst(label), label]);
         element.refreshUi();
       },

--- a/source/ui/TradeSettingsUi.ts
+++ b/source/ui/TradeSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type {
@@ -54,8 +53,8 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -66,23 +65,18 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
         },
       }),
     );
@@ -136,8 +130,8 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
               this.settingItem.triggerButton.inactive =
                 !this.setting.tradeBlackcoin.enabled || this.setting.tradeBlackcoin.trigger === -1;
             },
-            onSetTrigger: () => {
-              Dialog.prompt(
+            onSetTrigger: async () => {
+              const value = await Dialog.prompt(
                 host,
                 host.engine.i18n("ui.trigger.crypto.promptTitle"),
                 host.engine.i18n("ui.trigger.crypto.prompt", [
@@ -145,19 +139,14 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
                 ]),
                 host.renderAbsolute(this.setting.tradeBlackcoin.trigger),
                 host.engine.i18n("ui.trigger.crypto.promptExplainer"),
-              )
-                .then(value => {
-                  if (value === undefined || value === "" || value.startsWith("-")) {
-                    return;
-                  }
+              );
 
-                  this.setting.tradeBlackcoin.trigger =
-                    host.parseAbsolute(value) ?? this.setting.tradeBlackcoin.trigger;
-                })
-                .then(() => {
-                  this.refreshUi();
-                })
-                .catch(redirectErrorsToConsole(console));
+              if (value === undefined || value === "" || value.startsWith("-")) {
+                return;
+              }
+
+              this.setting.tradeBlackcoin.trigger =
+                host.parseAbsolute(value) ?? this.setting.tradeBlackcoin.trigger;
             },
           },
         ),
@@ -243,8 +232,8 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
             : host.renderPercentage(option.trigger, locale.selected, true),
         ]);
       },
-      onSetTrigger: () => {
-        Dialog.prompt(
+      onSetTrigger: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.trigger.prompt.percentage"),
           host.engine.i18n("ui.trigger.section.prompt", [
@@ -255,23 +244,18 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
           ]),
           option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
           host.engine.i18n("ui.trigger.section.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              option.trigger = -1;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            option.trigger = host.parsePercentage(value);
-          })
-          .then(() => {
-            element.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          option.trigger = -1;
+          return;
+        }
+
+        option.trigger = host.parsePercentage(value);
       },
       delimiter,
       upgradeIndicator,

--- a/source/ui/TradeSettingsUi.ts
+++ b/source/ui/TradeSettingsUi.ts
@@ -163,7 +163,7 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
         new SellButton(this, this.setting.tradeBlackcoin, locale),
       ]),
     );
-    this.addChild(listRaces);
+    this.addChildContent(listRaces);
 
     const listAddition = new SettingsList(this, {
       hasDisableAll: false,
@@ -194,7 +194,7 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
         },
       ),
     );
-    this.addChild(listAddition);
+    this.addChildContent(listAddition);
   }
 
   private _getTradeOption(

--- a/source/ui/TradeSettingsUi.ts
+++ b/source/ui/TradeSettingsUi.ts
@@ -10,7 +10,7 @@ import type {
 import type { TradeSettings, TradeSettingsItem } from "../settings/TradeSettings.js";
 import { ucfirst } from "../tools/Format.js";
 import { EmbassySettingsUi } from "./EmbassySettingsUi.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
+import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
 import { SeasonsList } from "./components/SeasonsList.js";
@@ -27,7 +27,7 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
     host: KittenScientists,
     settings: TradeSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: PanelOptions & SettingListItemOptions,
+    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.trade");
     super(

--- a/source/ui/TradeSettingsUi.ts
+++ b/source/ui/TradeSettingsUi.ts
@@ -72,6 +72,7 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -273,6 +274,7 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
       },
       delimiter,
       upgradeIndicator,
+      renderLabelTrigger: false,
     });
     const panel = new SettingsPanel(parent, option, element);
 

--- a/source/ui/TradeSettingsUi.ts
+++ b/source/ui/TradeSettingsUi.ts
@@ -47,8 +47,8 @@ export class TradeSettingsUi extends SettingsPanel<TradeSettings, SettingTrigger
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -1,6 +1,5 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import type { SupportedLocale } from "../Engine.js";
-import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { UpgradeSettings } from "../settings/UpgradeSettings.js";
 import stylesButton from "./components/Button.module.css";
@@ -11,26 +10,27 @@ import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import type { UiComponent } from "./components/UiComponent.js";
 
 export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTriggerListItem> {
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     settings: UpgradeSettings,
     locale: SettingOptions<SupportedLocale>,
     options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
-    const label = host.engine.i18n("ui.upgrade.upgrades");
+    const label = parent.host.engine.i18n("ui.upgrade.upgrades");
     super(
-      host,
+      parent,
       settings,
-      new SettingTriggerListItem(host, settings, locale, label, {
+      new SettingTriggerListItem(parent, settings, locale, label, {
         onCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.enable", [label]);
+          parent.host.engine.imessage("status.auto.enable", [label]);
           this.refreshUi();
           options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
-          host.engine.imessage("status.auto.disable", [label]);
+          parent.host.engine.imessage("status.auto.disable", [label]);
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
@@ -38,24 +38,24 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger() {
-          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+          this.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger", [
             settings.trigger === -1
-              ? host.engine.i18n("ui.trigger.section.inactive")
-              : host.renderPercentage(settings.trigger, locale.selected, true),
+              ? parent.host.engine.i18n("ui.trigger.section.inactive")
+              : parent.host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.percentage"),
-            host.engine.i18n("ui.trigger.section.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+            parent.host.engine.i18n("ui.trigger.section.prompt", [
               label,
               settings.trigger !== -1
-                ? host.renderPercentage(settings.trigger, locale.selected, true)
-                : host.engine.i18n("ui.infinity"),
+                ? parent.host.renderPercentage(settings.trigger, locale.selected, true)
+                : parent.host.engine.i18n("ui.infinity"),
             ]),
-            settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
-            host.engine.i18n("ui.trigger.section.promptExplainer"),
+            settings.trigger !== -1 ? parent.host.renderPercentage(settings.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.section.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -67,13 +67,13 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
             return;
           }
 
-          settings.trigger = host.parsePercentage(value);
+          settings.trigger = parent.host.parsePercentage(value);
         },
       }),
       options,
     );
 
-    const upgrades = host.game.workshop.upgrades.filter(
+    const upgrades = parent.host.game.workshop.upgrades.filter(
       upgrade => !isNil(this.setting.upgrades[upgrade.name]),
     );
 
@@ -85,12 +85,12 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
     )) {
       const option = this.setting.upgrades[upgrade.name];
 
-      const element = new SettingTriggerListItem(host, option, locale, upgrade.label, {
+      const element = new SettingTriggerListItem(parent, option, locale, upgrade.label, {
         onCheck: () => {
-          host.engine.imessage("status.sub.enable", [upgrade.label]);
+          parent.host.engine.imessage("status.sub.enable", [upgrade.label]);
         },
         onUnCheck: () => {
-          host.engine.imessage("status.sub.disable", [upgrade.label]);
+          parent.host.engine.imessage("status.sub.disable", [upgrade.label]);
         },
         onRefresh: () => {
           element.triggerButton.inactive = !option.enabled || option.trigger === -1;
@@ -98,26 +98,26 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
             settings.enabled && option.enabled && settings.trigger === -1 && option.trigger === -1;
         },
         onRefreshTrigger: () => {
-          element.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+          element.triggerButton.element[0].title = parent.host.engine.i18n("ui.trigger", [
             option.trigger < 0
               ? settings.trigger < 0
-                ? host.engine.i18n("ui.trigger.build.blocked", [label])
-                : `${host.renderPercentage(settings.trigger, locale.selected, true)} (${host.engine.i18n("ui.trigger.section.inherited")})`
-              : host.renderPercentage(option.trigger, locale.selected, true),
+                ? parent.host.engine.i18n("ui.trigger.build.blocked", [label])
+                : `${parent.host.renderPercentage(settings.trigger, locale.selected, true)} (${parent.host.engine.i18n("ui.trigger.section.inherited")})`
+              : parent.host.renderPercentage(option.trigger, locale.selected, true),
           ]);
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            host,
-            host.engine.i18n("ui.trigger.prompt.percentage"),
-            host.engine.i18n("ui.trigger.section.prompt", [
+            parent,
+            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
+            parent.host.engine.i18n("ui.trigger.section.prompt", [
               label,
               option.trigger !== -1
-                ? host.renderPercentage(option.trigger, locale.selected, true)
-                : host.engine.i18n("ui.trigger.section.inherited"),
+                ? parent.host.renderPercentage(option.trigger, locale.selected, true)
+                : parent.host.engine.i18n("ui.trigger.section.inherited"),
             ]),
-            option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
-            host.engine.i18n("ui.trigger.section.promptExplainer"),
+            option.trigger !== -1 ? parent.host.renderPercentage(option.trigger) : "",
+            parent.host.engine.i18n("ui.trigger.section.promptExplainer"),
           );
 
           if (value === undefined) {
@@ -129,12 +129,12 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
             return;
           }
 
-          option.trigger = host.parsePercentage(value);
+          option.trigger = parent.host.parsePercentage(value);
         },
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);
 
-      if (host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
+      if (parent.host.engine.localeSupportsFirstLetterSplits(locale.selected)) {
         if (lastLabel[0] !== upgrade.label[0]) {
           if (!isNil(lastElement)) {
             lastElement.element.addClass(stylesDelimiter.delimiter);
@@ -149,6 +149,6 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
       lastLabel = upgrade.label;
     }
 
-    this.addChild(new SettingsList(host, { children: items }));
+    this.addChild(new SettingsList(parent, { children: items }));
   }
 }

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -38,8 +38,8 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [
             settings.trigger === -1
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -63,6 +63,7 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -124,6 +125,7 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
 
           option.trigger = this.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);
 

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -5,21 +5,20 @@ import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
 import type { UpgradeSettings } from "../settings/UpgradeSettings.js";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import stylesDelimiter from "./components/Delimiter.module.css";
 import { Dialog } from "./components/Dialog.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import type { SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: UpgradeSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingTriggerListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.upgrade.upgrades");
     super(

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -14,7 +14,7 @@ import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 
-export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings> {
+export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTriggerListItem> {
   constructor(
     host: KittenScientists,
     settings: UpgradeSettings,
@@ -36,9 +36,8 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger: item => {
           item.triggerButton.element[0].title = host.engine.i18n("ui.trigger", [

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -45,8 +44,8 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -57,23 +56,18 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
         },
       }),
       options,
@@ -112,8 +106,8 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
               : host.renderPercentage(option.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -124,23 +118,18 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
             ]),
             option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                option.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              option.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              element.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            option.trigger = -1;
+            return;
+          }
+
+          option.trigger = host.parsePercentage(value);
         },
       });
       element.triggerButton.element.addClass(stylesButton.lastHeadAction);

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -142,6 +142,6 @@ export class UpgradeSettingsUi extends SettingsPanel<UpgradeSettings, SettingTri
       lastLabel = upgrade.label;
     }
 
-    this.addChild(new SettingsList(this).addChildren(items));
+    this.addChildContent(new SettingsList(this).addChildren(items));
   }
 }

--- a/source/ui/UserInterface.ts
+++ b/source/ui/UserInterface.ts
@@ -170,4 +170,10 @@ export class UserInterface extends UiComponent {
   refreshUi(): void {
     this._engineUi.refreshUi();
   }
+
+  forceFullRefresh(): void {
+    console.warn(...cl("Forcing full user interface refresh!"));
+    super.requestRefresh(true);
+    this.requestRefresh();
+  }
 }

--- a/source/ui/UserInterface.ts
+++ b/source/ui/UserInterface.ts
@@ -65,8 +65,9 @@ export class UserInterface extends UiComponent {
       this.stateManagementUi,
       new InternalsUi(this, engine.settings, engine.settings.locale),
     ];
-
-    //this._installCss();
+    for (const section of this._sections) {
+      this.children.add(section);
+    }
 
     const ks = $("<div/>").addClass(styles.ui);
 
@@ -141,11 +142,29 @@ export class UserInterface extends UiComponent {
       right.prepend(ks);
     }
     this.element = ks;
+
+    this.refresh(true);
+  }
+
+  toString(): string {
+    return `[${UserInterface.name}#${this.componentId}]`;
   }
 
   destroy() {
     this.showActivity.remove();
     this.element.remove();
+  }
+
+  override requestRefresh() {
+    if (this._needsRefresh) {
+      return;
+    }
+
+    this._needsRefresh = true;
+    setTimeout(() => {
+      console.warn(...cl("Refreshing UI...."));
+      this.refresh();
+    }, 0);
   }
 
   refreshUi(): void {

--- a/source/ui/UserInterface.ts
+++ b/source/ui/UserInterface.ts
@@ -169,8 +169,5 @@ export class UserInterface extends UiComponent {
 
   refreshUi(): void {
     this._engineUi.refreshUi();
-    for (const section of this._sections) {
-      section.refreshUi();
-    }
   }
 }

--- a/source/ui/UserInterface.ts
+++ b/source/ui/UserInterface.ts
@@ -41,29 +41,29 @@ export class UserInterface extends UiComponent {
   stateManagementUi: StateManagementUi;
 
   constructor(host: KittenScientists) {
-    super(host, {});
+    super({ host }, {});
 
     const engine = host.engine;
-    this._engineUi = new EngineSettingsUi(host, engine.settings);
+    this._engineUi = new EngineSettingsUi(this, engine.settings);
     this.stateManagementUi = new StateManagementUi(
-      host,
+      this,
       engine.settings.states,
       engine.settings.locale,
     );
     this._sections = [
-      new BonfireSettingsUi(host, engine.bonfireManager.settings, engine.settings.locale),
-      new VillageSettingsUi(host, engine.villageManager.settings, engine.settings.locale),
-      new ScienceSettingsUi(host, engine.scienceManager.settings, engine.settings.locale),
-      new WorkshopSettingsUi(host, engine.workshopManager.settings, engine.settings.locale),
-      new ResourcesSettingsUi(host, engine.settings.resources, engine.settings.locale),
-      new TradeSettingsUi(host, engine.tradeManager.settings, engine.settings.locale),
-      new ReligionSettingsUi(host, engine.religionManager.settings, engine.settings.locale),
-      new SpaceSettingsUi(host, engine.spaceManager.settings, engine.settings.locale),
-      new TimeSettingsUi(host, engine.timeManager.settings, engine.settings.locale),
-      new TimeControlSettingsUi(host, engine.timeControlManager.settings, engine.settings.locale),
-      new LogFiltersSettingsUi(host, engine.settings.filters),
+      new BonfireSettingsUi(this, engine.bonfireManager.settings, engine.settings.locale),
+      new VillageSettingsUi(this, engine.villageManager.settings, engine.settings.locale),
+      new ScienceSettingsUi(this, engine.scienceManager.settings, engine.settings.locale),
+      new WorkshopSettingsUi(this, engine.workshopManager.settings, engine.settings.locale),
+      new ResourcesSettingsUi(this, engine.settings.resources, engine.settings.locale),
+      new TradeSettingsUi(this, engine.tradeManager.settings, engine.settings.locale),
+      new ReligionSettingsUi(this, engine.religionManager.settings, engine.settings.locale),
+      new SpaceSettingsUi(this, engine.spaceManager.settings, engine.settings.locale),
+      new TimeSettingsUi(this, engine.timeManager.settings, engine.settings.locale),
+      new TimeControlSettingsUi(this, engine.timeControlManager.settings, engine.settings.locale),
+      new LogFiltersSettingsUi(this, engine.settings.filters),
       this.stateManagementUi,
-      new InternalsUi(host, engine.settings, engine.settings.locale),
+      new InternalsUi(this, engine.settings, engine.settings.locale),
     ];
 
     //this._installCss();

--- a/source/ui/UserInterface.ts
+++ b/source/ui/UserInterface.ts
@@ -41,7 +41,7 @@ export class UserInterface extends UiComponent {
   stateManagementUi: StateManagementUi;
 
   constructor(host: KittenScientists) {
-    super(host);
+    super(host, {});
 
     const engine = host.engine;
     this._engineUi = new EngineSettingsUi(host, engine.settings);

--- a/source/ui/VillageSettingsUi.ts
+++ b/source/ui/VillageSettingsUi.ts
@@ -291,7 +291,7 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
                 ]);
       },
       onSetMax,
-    }).addChildrenHead([new Container(this, { classes: [stylesLabelListItem.fillSpace] })]);
+    }); //.addChildrenHead([new Container(this, { classes: [stylesLabelListItem.fillSpace] })]);
     element.maxButton.element.addClass(stylesButton.lastHeadAction);
     return element;
   }

--- a/source/ui/VillageSettingsUi.ts
+++ b/source/ui/VillageSettingsUi.ts
@@ -5,7 +5,6 @@ import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingMax, SettingOptions } from "../settings/Settings.js";
 import type { VillageSettings } from "../settings/VillageSettings.js";
 import stylesButton from "./components/Button.module.css";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
 import { Container } from "./components/Container.js";
 import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
@@ -15,7 +14,7 @@ import { SettingListItem, type SettingListItemOptions } from "./components/Setti
 import { SettingMaxListItem } from "./components/SettingMaxListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel } from "./components/SettingsPanel.js";
+import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
 
 export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
   private readonly _hunt: SettingTriggerListItem;
@@ -28,7 +27,7 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     host: KittenScientists,
     settings: VillageSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.distribute");
     super(

--- a/source/ui/VillageSettingsUi.ts
+++ b/source/ui/VillageSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingMax, SettingOptions } from "../settings/Settings.js";
@@ -87,8 +86,8 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
           this._hunt.triggerButton.ineffective =
             this.setting.enabled && this.setting.hunt.enabled && this.setting.hunt.trigger === -1;
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.hunt.prompt", [
@@ -96,18 +95,13 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
             ]),
             host.renderPercentage(this.setting.hunt.trigger),
             host.engine.i18n("ui.trigger.hunt.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined || value === "" || value.startsWith("-")) {
-                return;
-              }
+          );
 
-              this.setting.hunt.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this._hunt.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === undefined || value === "" || value.startsWith("-")) {
+            return;
+          }
+
+          this.setting.hunt.trigger = host.parsePercentage(value);
         },
       },
     );
@@ -148,8 +142,8 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
             this.setting.promoteKittens.enabled &&
             this.setting.promoteKittens.trigger === -1;
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.promoteKittens.promptTitle"),
             host.engine.i18n("ui.trigger.promoteKittens.prompt", [
@@ -157,18 +151,13 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
             ]),
             host.renderPercentage(this.setting.promoteKittens.trigger),
             host.engine.i18n("ui.trigger.promoteKittens.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined || value === "" || value.startsWith("-")) {
-                return;
-              }
+          );
 
-              this.setting.promoteKittens.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === undefined || value === "" || value.startsWith("-")) {
+            return;
+          }
+
+          this.setting.promoteKittens.trigger = host.parsePercentage(value);
         },
       },
     );
@@ -240,8 +229,8 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     label: string,
     delimiter = false,
   ) {
-    const onSetMax = () => {
-      Dialog.prompt(
+    const onSetMax = async () => {
+      const value = await Dialog.prompt(
         host,
         host.engine.i18n("ui.max.distribute.prompt", [label]),
         host.engine.i18n("ui.max.distribute.promptTitle", [
@@ -250,27 +239,22 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
         ]),
         host.renderAbsolute(option.max),
         host.engine.i18n("ui.max.distribute.promptExplainer"),
-      )
-        .then(value => {
-          if (value === undefined) {
-            return;
-          }
+      );
 
-          if (value === "" || value.startsWith("-")) {
-            option.max = -1;
-            return;
-          }
+      if (value === undefined) {
+        return;
+      }
 
-          if (value === "0") {
-            option.enabled = false;
-          }
+      if (value === "" || value.startsWith("-")) {
+        option.max = -1;
+        return;
+      }
 
-          option.max = host.parseAbsolute(value) ?? option.max;
-        })
-        .then(() => {
-          this.refreshUi();
-        })
-        .catch(redirectErrorsToConsole(console));
+      if (value === "0") {
+        option.enabled = false;
+      }
+
+      option.max = host.parseAbsolute(value) ?? option.max;
     };
 
     const element = new SettingMaxListItem(host, option, label, {

--- a/source/ui/VillageSettingsUi.ts
+++ b/source/ui/VillageSettingsUi.ts
@@ -8,11 +8,11 @@ import { Dialog } from "./components/Dialog.js";
 import { HeaderListItem } from "./components/HeaderListItem.js";
 import stylesLabelListItem from "./components/LabelListItem.module.css";
 import { OptionsListItem } from "./components/OptionsListItem.js";
-import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
+import { SettingListItem } from "./components/SettingListItem.js";
 import { SettingMaxListItem } from "./components/SettingMaxListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
 import { SettingsList } from "./components/SettingsList.js";
-import { SettingsPanel, type SettingsPanelOptions } from "./components/SettingsPanel.js";
+import { SettingsPanel } from "./components/SettingsPanel.js";
 import type { UiComponent } from "./components/UiComponent.js";
 
 export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
@@ -26,64 +26,53 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     parent: UiComponent,
     settings: VillageSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: SettingsPanelOptions<SettingListItem> & SettingListItemOptions,
   ) {
     const label = parent.host.engine.i18n("ui.distribute");
     super(
       parent,
       settings,
       new SettingListItem(parent, settings, label, {
-        childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
         onCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.enable", [label]);
-          this.refreshUi();
-          options?.onCheck?.(isBatchProcess);
         },
         onUnCheck: (isBatchProcess?: boolean) => {
           parent.host.engine.imessage("status.auto.disable", [label]);
-          this.refreshUi();
-          options?.onUnCheck?.(isBatchProcess);
         },
-      }),
+      }).addChildrenHead([new Container(parent, { classes: [stylesLabelListItem.fillSpace] })]),
     );
 
-    const listJobs = new SettingsList(parent, {
-      children: parent.host.game.village.jobs
+    const listJobs = new SettingsList(this).addChildren(
+      this.host.game.village.jobs
         .filter(item => !isNil(this.setting.jobs[item.name]))
         .map(job =>
           this._getDistributeOption(
-            parent,
             this.setting.jobs[job.name],
             locale.selected,
             settings,
             job.title,
           ),
         ),
-    });
+    );
     this.addChild(listJobs);
 
-    const listAddition = new SettingsList(parent, {
+    const listAddition = new SettingsList(this, {
       hasDisableAll: false,
       hasEnableAll: false,
     });
 
-    listAddition.addChild(new HeaderListItem(parent, parent.host.engine.i18n("ui.additional")));
+    listAddition.addChild(new HeaderListItem(this, this.host.engine.i18n("ui.additional")));
 
     this._hunt = new SettingTriggerListItem(
-      parent,
+      this,
       this.setting.hunt,
       locale,
-      parent.host.engine.i18n("option.hunt"),
+      this.host.engine.i18n("option.hunt"),
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.hunt"),
-          ]);
+          this.host.engine.imessage("status.sub.enable", [this.host.engine.i18n("option.hunt")]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.hunt"),
-          ]);
+          this.host.engine.imessage("status.sub.disable", [this.host.engine.i18n("option.hunt")]);
         },
         onRefresh: () => {
           this._hunt.triggerButton.inactive = !this.setting.hunt.enabled;
@@ -92,20 +81,20 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            parent,
-            parent.host.engine.i18n("ui.trigger.prompt.percentage"),
-            parent.host.engine.i18n("ui.trigger.hunt.prompt", [
-              parent.host.renderPercentage(this.setting.hunt.trigger, locale.selected, true),
+            this,
+            this.host.engine.i18n("ui.trigger.prompt.percentage"),
+            this.host.engine.i18n("ui.trigger.hunt.prompt", [
+              this.host.renderPercentage(this.setting.hunt.trigger, locale.selected, true),
             ]),
-            parent.host.renderPercentage(this.setting.hunt.trigger),
-            parent.host.engine.i18n("ui.trigger.hunt.promptExplainer"),
+            this.host.renderPercentage(this.setting.hunt.trigger),
+            this.host.engine.i18n("ui.trigger.hunt.promptExplainer"),
           );
 
           if (value === undefined || value === "" || value.startsWith("-")) {
             return;
           }
 
-          this.setting.hunt.trigger = parent.host.parsePercentage(value);
+          this.setting.hunt.trigger = this.host.parsePercentage(value);
         },
       },
     );
@@ -113,18 +102,18 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     listAddition.addChild(this._hunt);
 
     this._festivals = new SettingListItem(
-      parent,
+      this,
       this.setting.holdFestivals,
-      parent.host.engine.i18n("option.festival"),
+      this.host.engine.i18n("option.festival"),
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.festival"),
+          this.host.engine.imessage("status.sub.enable", [
+            this.host.engine.i18n("option.festival"),
           ]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.festival"),
+          this.host.engine.imessage("status.sub.disable", [
+            this.host.engine.i18n("option.festival"),
           ]);
         },
       },
@@ -132,19 +121,19 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     listAddition.addChild(this._festivals);
 
     this._promoteKittens = new SettingTriggerListItem(
-      parent,
+      this,
       this.setting.promoteKittens,
       locale,
-      parent.host.engine.i18n("option.promotekittens"),
+      this.host.engine.i18n("option.promotekittens"),
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.promotekittens"),
+          this.host.engine.imessage("status.sub.enable", [
+            this.host.engine.i18n("option.promotekittens"),
           ]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.promotekittens"),
+          this.host.engine.imessage("status.sub.disable", [
+            this.host.engine.i18n("option.promotekittens"),
           ]);
         },
         onRefresh: () => {
@@ -156,24 +145,24 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
         },
         onSetTrigger: async () => {
           const value = await Dialog.prompt(
-            parent,
-            parent.host.engine.i18n("ui.trigger.promoteKittens.promptTitle"),
-            parent.host.engine.i18n("ui.trigger.promoteKittens.prompt", [
-              parent.host.renderPercentage(
+            this,
+            this.host.engine.i18n("ui.trigger.promoteKittens.promptTitle"),
+            this.host.engine.i18n("ui.trigger.promoteKittens.prompt", [
+              this.host.renderPercentage(
                 this.setting.promoteKittens.trigger,
                 locale.selected,
                 true,
               ),
             ]),
-            parent.host.renderPercentage(this.setting.promoteKittens.trigger),
-            parent.host.engine.i18n("ui.trigger.promoteKittens.promptExplainer"),
+            this.host.renderPercentage(this.setting.promoteKittens.trigger),
+            this.host.engine.i18n("ui.trigger.promoteKittens.promptExplainer"),
           );
 
           if (value === undefined || value === "" || value.startsWith("-")) {
             return;
           }
 
-          this.setting.promoteKittens.trigger = parent.host.parsePercentage(value);
+          this.setting.promoteKittens.trigger = this.host.parsePercentage(value);
         },
       },
     );
@@ -181,18 +170,16 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     listAddition.addChild(this._promoteKittens);
 
     this._promoteLeader = new SettingListItem(
-      parent,
+      this,
       this.setting.promoteLeader,
-      parent.host.engine.i18n("option.promote"),
+      this.host.engine.i18n("option.promote"),
       {
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.promote"),
-          ]);
+          this.host.engine.imessage("status.sub.enable", [this.host.engine.i18n("option.promote")]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.promote"),
+          this.host.engine.imessage("status.sub.disable", [
+            this.host.engine.i18n("option.promote"),
           ]);
         },
       },
@@ -201,52 +188,46 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
 
     for (const option of this.setting.electLeader.job.options) {
       if (option.value === "any") {
-        option.label = parent.host.engine.i18n("option.elect.job.any");
+        option.label = this.host.engine.i18n("option.elect.job.any");
       } else {
-        option.label = parent.host.engine.i18n(`$village.job.${option.value}`);
+        option.label = this.host.engine.i18n(`$village.job.${option.value}`);
       }
     }
 
     for (const option of this.setting.electLeader.trait.options) {
-      option.label = parent.host.engine.i18n(`$village.trait.${option.value}`);
+      option.label = this.host.engine.i18n(`$village.trait.${option.value}`);
     }
 
     this._electLeader = new SettingListItem(
-      parent,
+      this,
       this.setting.electLeader,
-      parent.host.engine.i18n("option.elect"),
+      this.host.engine.i18n("option.elect"),
       {
-        children: [
-          new OptionsListItem(
-            parent,
-            parent.host.engine.i18n("option.elect.job"),
-            this.setting.electLeader.job,
-          ),
-          new OptionsListItem(
-            parent,
-            parent.host.engine.i18n("option.elect.trait"),
-            this.setting.electLeader.trait,
-          ),
-        ],
         onCheck: () => {
-          parent.host.engine.imessage("status.sub.enable", [
-            parent.host.engine.i18n("option.elect"),
-          ]);
+          this.host.engine.imessage("status.sub.enable", [this.host.engine.i18n("option.elect")]);
         },
         onUnCheck: () => {
-          parent.host.engine.imessage("status.sub.disable", [
-            parent.host.engine.i18n("option.elect"),
-          ]);
+          this.host.engine.imessage("status.sub.disable", [this.host.engine.i18n("option.elect")]);
         },
       },
-    );
+    ).addChildren([
+      new OptionsListItem(
+        this,
+        this.host.engine.i18n("option.elect.job"),
+        this.setting.electLeader.job,
+      ),
+      new OptionsListItem(
+        this,
+        this.host.engine.i18n("option.elect.trait"),
+        this.setting.electLeader.trait,
+      ),
+    ]);
     listAddition.addChild(this._electLeader);
 
     this.addChild(listAddition);
   }
 
   private _getDistributeOption(
-    parent: UiComponent,
     option: SettingMax,
     locale: SupportedLocale,
     sectionSetting: VillageSettings,
@@ -255,14 +236,14 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
   ) {
     const onSetMax = async () => {
       const value = await Dialog.prompt(
-        parent,
-        parent.host.engine.i18n("ui.max.distribute.prompt", [label]),
-        parent.host.engine.i18n("ui.max.distribute.promptTitle", [
+        this,
+        this.host.engine.i18n("ui.max.distribute.prompt", [label]),
+        this.host.engine.i18n("ui.max.distribute.promptTitle", [
           label,
-          parent.host.renderAbsolute(option.max, locale),
+          this.host.renderAbsolute(option.max, locale),
         ]),
-        parent.host.renderAbsolute(option.max),
-        parent.host.engine.i18n("ui.max.distribute.promptExplainer"),
+        this.host.renderAbsolute(option.max),
+        this.host.engine.i18n("ui.max.distribute.promptExplainer"),
       );
 
       if (value === undefined) {
@@ -278,20 +259,19 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
         option.enabled = false;
       }
 
-      option.max = parent.host.parseAbsolute(value) ?? option.max;
+      option.max = this.host.parseAbsolute(value) ?? option.max;
     };
 
-    const element = new SettingMaxListItem(parent, option, label, {
-      childrenHead: [new Container(parent, { classes: [stylesLabelListItem.fillSpace] })],
+    const element = new SettingMaxListItem(this, option, label, {
       delimiter,
       onCheck: (isBatchProcess?: boolean) => {
-        parent.host.engine.imessage("status.sub.enable", [label]);
+        this.host.engine.imessage("status.sub.enable", [label]);
         if (option.max === 0 && !isBatchProcess) {
           onSetMax();
         }
       },
       onUnCheck: () => {
-        parent.host.engine.imessage("status.sub.disable", [label]);
+        this.host.engine.imessage("status.sub.disable", [label]);
       },
       onRefresh: () => {
         element.maxButton.inactive = !option.enabled || option.max === -1;
@@ -299,19 +279,19 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
           sectionSetting.enabled && option.enabled && option.max === 0;
       },
       onRefreshMax: () => {
-        element.maxButton.updateLabel(parent.host.renderAbsolute(option.max));
+        element.maxButton.updateLabel(this.host.renderAbsolute(option.max));
         element.maxButton.element[0].title =
           option.max < 0
-            ? parent.host.engine.i18n("ui.max.distribute.titleInfinite", [label])
+            ? this.host.engine.i18n("ui.max.distribute.titleInfinite", [label])
             : option.max === 0
-              ? parent.host.engine.i18n("ui.max.distribute.titleZero", [label])
-              : parent.host.engine.i18n("ui.max.distribute.title", [
-                  parent.host.renderAbsolute(option.max),
+              ? this.host.engine.i18n("ui.max.distribute.titleZero", [label])
+              : this.host.engine.i18n("ui.max.distribute.title", [
+                  this.host.renderAbsolute(option.max),
                   label,
                 ]);
       },
       onSetMax,
-    });
+    }).addChildrenHead([new Container(this, { classes: [stylesLabelListItem.fillSpace] })]);
     element.maxButton.element.addClass(stylesButton.lastHeadAction);
     return element;
   }

--- a/source/ui/VillageSettingsUi.ts
+++ b/source/ui/VillageSettingsUi.ts
@@ -53,7 +53,7 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
           ),
         ),
     );
-    this.addChild(listJobs);
+    this.addChildContent(listJobs);
 
     const listAddition = new SettingsList(this, {
       hasDisableAll: false,
@@ -224,7 +224,7 @@ export class VillageSettingsUi extends SettingsPanel<VillageSettings> {
     ]);
     listAddition.addChild(this._electLeader);
 
-    this.addChild(listAddition);
+    this.addChildContent(listAddition);
   }
 
   private _getDistributeOption(

--- a/source/ui/WorkshopSettingsUi.ts
+++ b/source/ui/WorkshopSettingsUi.ts
@@ -42,8 +42,8 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
         onRefresh: () => {
           this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
-        onRefreshTrigger: item => {
-          item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
+        onRefreshTrigger() {
+          this.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [
             settings.trigger < 0
               ? host.engine.i18n("ui.trigger.section.inactive")
               : host.renderPercentage(settings.trigger, locale.selected, true),

--- a/source/ui/WorkshopSettingsUi.ts
+++ b/source/ui/WorkshopSettingsUi.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../Engine.js";
 import type { KittenScientists } from "../KittenScientists.js";
 import type { SettingOptions } from "../settings/Settings.js";
@@ -49,8 +48,8 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
               : host.renderPercentage(settings.trigger, locale.selected, true),
           ]);
         },
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -61,23 +60,18 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
             ]),
             settings.trigger !== -1 ? host.renderPercentage(settings.trigger) : "",
             host.engine.i18n("ui.trigger.section.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                settings.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              settings.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              this.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            settings.trigger = -1;
+            return;
+          }
+
+          settings.trigger = host.parsePercentage(value);
         },
       }),
     );
@@ -98,8 +92,8 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
 
     this._crafts = [];
     for (const [option, label] of preparedCrafts) {
-      const onSetMax = () => {
-        Dialog.prompt(
+      const onSetMax = async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("ui.max.craft.prompt", [label]),
           host.engine.i18n("ui.max.craft.promptTitle", [
@@ -108,27 +102,22 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
           ]),
           host.renderAbsolute(option.max),
           host.engine.i18n("ui.max.craft.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              option.max = -1;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            if (value === "0") {
-              option.enabled = false;
-            }
+        if (value === "" || value.startsWith("-")) {
+          option.max = -1;
+          return;
+        }
 
-            option.max = host.parseAbsolute(value) ?? option.max;
-          })
-          .then(() => {
-            this.refreshUi();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "0") {
+          option.enabled = false;
+        }
+
+        option.max = host.parseAbsolute(value) ?? option.max;
       };
 
       const element = new WorkshopCraftListItem(host, option, locale, label, {
@@ -175,8 +164,8 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
           ]);
         },
         onSetMax,
-        onSetTrigger: () => {
-          Dialog.prompt(
+        onSetTrigger: async () => {
+          const value = await Dialog.prompt(
             host,
             host.engine.i18n("ui.trigger.prompt.percentage"),
             host.engine.i18n("ui.trigger.section.prompt", [
@@ -187,23 +176,18 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
             ]),
             option.trigger !== -1 ? host.renderPercentage(option.trigger) : "",
             host.engine.i18n("ui.trigger.build.promptExplainer"),
-          )
-            .then(value => {
-              if (value === undefined) {
-                return;
-              }
+          );
 
-              if (value === "" || value.startsWith("-")) {
-                option.trigger = -1;
-                return;
-              }
+          if (value === undefined) {
+            return;
+          }
 
-              option.trigger = host.parsePercentage(value);
-            })
-            .then(() => {
-              element.refreshUi();
-            })
-            .catch(redirectErrorsToConsole(console));
+          if (value === "" || value.startsWith("-")) {
+            option.trigger = -1;
+            return;
+          }
+
+          option.trigger = host.parsePercentage(value);
         },
       });
       this._crafts.push(element);

--- a/source/ui/WorkshopSettingsUi.ts
+++ b/source/ui/WorkshopSettingsUi.ts
@@ -15,14 +15,14 @@ import { SettingsList } from "./components/SettingsList.js";
 import { SettingsPanel } from "./components/SettingsPanel.js";
 import { WorkshopCraftListItem } from "./components/WorkshopCraftListItem.js";
 
-export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings> {
+export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingTriggerListItem> {
   private readonly _crafts: Array<SettingListItem>;
 
   constructor(
     host: KittenScientists,
     settings: WorkshopSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: Partial<PanelOptions & SettingListItemOptions>,
+    options?: PanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.craft");
     super(
@@ -39,9 +39,8 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings> {
           this.refreshUi();
           options?.onUnCheck?.(isBatchProcess);
         },
-        onRefresh: item => {
-          (item as SettingTriggerListItem).triggerButton.inactive =
-            !settings.enabled || settings.trigger === -1;
+        onRefresh: () => {
+          this.settingItem.triggerButton.inactive = !settings.enabled || settings.trigger === -1;
         },
         onRefreshTrigger: item => {
           item.triggerButton.element[0].title = host.engine.i18n("ui.trigger.section", [

--- a/source/ui/WorkshopSettingsUi.ts
+++ b/source/ui/WorkshopSettingsUi.ts
@@ -216,12 +216,12 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
     const listCrafts = new SettingsList(this, {
       onReset: () => {
         this.setting.load({ resources: new WorkshopSettings().resources });
-        this.refreshUi();
+        this.requestRefresh();
       },
     }).addChildren(this._crafts);
-    this.addChild(listCrafts);
+    this.addChildContent(listCrafts);
 
-    this.addChild(
+    this.addChildContent(
       new SettingsList(this, {
         hasDisableAll: false,
         hasEnableAll: false,

--- a/source/ui/WorkshopSettingsUi.ts
+++ b/source/ui/WorkshopSettingsUi.ts
@@ -67,6 +67,7 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
 
           settings.trigger = parent.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       }),
     );
 
@@ -186,6 +187,7 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
 
           option.trigger = this.host.parsePercentage(value);
         },
+        renderLabelTrigger: false,
       });
       this._crafts.push(element);
 

--- a/source/ui/WorkshopSettingsUi.ts
+++ b/source/ui/WorkshopSettingsUi.ts
@@ -7,7 +7,7 @@ import { type CraftSettingsItem, WorkshopSettings } from "../settings/WorkshopSe
 import { ucfirst } from "../tools/Format.js";
 import type { ResourceCraftable } from "../types/index.js";
 import { UpgradeSettingsUi } from "./UpgradeSettingsUi.js";
-import type { PanelOptions } from "./components/CollapsiblePanel.js";
+import type { CollapsiblePanelOptions } from "./components/CollapsiblePanel.js";
 import { Dialog } from "./components/Dialog.js";
 import { SettingListItem, type SettingListItemOptions } from "./components/SettingListItem.js";
 import { SettingTriggerListItem } from "./components/SettingTriggerListItem.js";
@@ -22,7 +22,7 @@ export class WorkshopSettingsUi extends SettingsPanel<WorkshopSettings, SettingT
     host: KittenScientists,
     settings: WorkshopSettings,
     locale: SettingOptions<SupportedLocale>,
-    options?: PanelOptions & SettingListItemOptions,
+    options?: CollapsiblePanelOptions & SettingListItemOptions,
   ) {
     const label = host.engine.i18n("ui.craft");
     super(

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -15,7 +15,6 @@ export type ButtonOptions = IconButtonOptions & {
  */
 export class Button extends UiComponent {
   declare readonly _options: ButtonOptions;
-
   protected readonly _iconElement: JQuery | undefined;
   readonly element: JQuery;
   readOnly: boolean;

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -4,17 +4,17 @@ import type { IconButtonOptions } from "./IconButton.js";
 import { UiComponent } from "./UiComponent.js";
 
 export type ButtonOptions = IconButtonOptions & {
-  readonly border: boolean;
-  readonly alignment: "left" | "right";
-  readonly title: string;
-  readonly classes: Array<string>;
+  readonly border?: boolean;
+  readonly alignment?: "left" | "right";
+  readonly title?: string;
+  readonly classes?: Array<string>;
 };
 
 /**
  * A button that has a label and can optionally have an SVG icon.
  */
 export class Button extends UiComponent {
-  declare readonly _options: Partial<ButtonOptions>;
+  declare readonly _options: ButtonOptions;
 
   protected readonly _iconElement: JQuery | undefined;
   readonly element: JQuery;
@@ -34,7 +34,7 @@ export class Button extends UiComponent {
     host: KittenScientists,
     label: string,
     pathData: string | null = null,
-    options?: Partial<ButtonOptions>,
+    options?: ButtonOptions,
   ) {
     super(host, { ...options, children: [] });
 

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -3,12 +3,13 @@ import styles from "./Button.module.css";
 import type { IconButtonOptions } from "./IconButton.js";
 import { UiComponent } from "./UiComponent.js";
 
-export type ButtonOptions = IconButtonOptions & {
-  readonly border?: boolean;
-  readonly alignment?: "left" | "right";
-  readonly title?: string;
-  readonly classes?: Array<string>;
-} & ThisType<Button>;
+export type ButtonOptions = ThisType<Button> &
+  IconButtonOptions & {
+    readonly border?: boolean;
+    readonly alignment?: "left" | "right";
+    readonly title?: string;
+    readonly classes?: Array<string>;
+  };
 
 /**
  * A button that has a label and can optionally have an SVG icon.

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -7,6 +7,7 @@ export type ButtonOptions = IconButtonOptions & {
   readonly border: boolean;
   readonly alignment: "left" | "right";
   readonly title: string;
+  readonly classes: Array<string>;
 };
 
 /**
@@ -35,7 +36,7 @@ export class Button extends UiComponent {
     pathData: string | null = null,
     options?: Partial<ButtonOptions>,
   ) {
-    super(host, { ...options, children: [], classes: [] });
+    super(host, { ...options, children: [] });
 
     this.element = $("<div/>", { title: options?.title }).addClass(styles.button).text(label);
 

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -8,7 +8,6 @@ export type ButtonOptions = ThisType<Button> &
     readonly alignment?: "left" | "right";
     readonly title?: string;
     readonly classes?: Array<string>;
-    readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
   };
 
 /**

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -8,7 +8,7 @@ export type ButtonOptions = IconButtonOptions & {
   readonly alignment?: "left" | "right";
   readonly title?: string;
   readonly classes?: Array<string>;
-};
+} & ThisType<Button>;
 
 /**
  * A button that has a label and can optionally have an SVG icon.

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import styles from "./Button.module.css";
 import type { IconButtonOptions } from "./IconButton.js";
 import { UiComponent } from "./UiComponent.js";
@@ -15,7 +14,7 @@ export type ButtonOptions = ThisType<Button> &
  * A button that has a label and can optionally have an SVG icon.
  */
 export class Button extends UiComponent {
-  declare readonly _options: ButtonOptions;
+  declare readonly options: ButtonOptions;
   protected readonly _iconElement: JQuery | undefined;
   readonly element: JQuery;
   readOnly: boolean;
@@ -31,12 +30,12 @@ export class Button extends UiComponent {
    * @param options - Options for the icon button.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     label: string,
     pathData: string | null = null,
     options?: ButtonOptions,
   ) {
-    super(host, { ...options, children: [] });
+    super(parent, { ...options, children: [] });
 
     this.element = $("<div/>", { title: options?.title }).addClass(styles.button).text(label);
 
@@ -80,7 +79,7 @@ export class Button extends UiComponent {
   updateLabel(label: string) {
     this.element.text(label);
     if (this._iconElement !== undefined) {
-      if (this._options.alignment === "right") {
+      if (this.options.alignment === "right") {
         this.element.append(this._iconElement);
       } else {
         this.element.prepend(this._iconElement);

--- a/source/ui/components/Button.ts
+++ b/source/ui/components/Button.ts
@@ -8,6 +8,7 @@ export type ButtonOptions = ThisType<Button> &
     readonly alignment?: "left" | "right";
     readonly title?: string;
     readonly classes?: Array<string>;
+    readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
   };
 
 /**
@@ -35,7 +36,7 @@ export class Button extends UiComponent {
     pathData: string | null = null,
     options?: ButtonOptions,
   ) {
-    super(parent, { ...options, children: [] });
+    super(parent, { ...options });
 
     this.element = $("<div/>", { title: options?.title }).addClass(styles.button).text(label);
 
@@ -70,10 +71,13 @@ export class Button extends UiComponent {
       this.click();
     });
 
-    this.addChildren(options?.children);
     this.readOnly = options?.readOnly ?? false;
     this.inactive = options?.inactive ?? false;
     this.ineffective = false;
+  }
+
+  toString(): string {
+    return `[${Button.name}#${this.componentId}]`;
   }
 
   updateLabel(label: string) {
@@ -90,17 +94,17 @@ export class Button extends UiComponent {
     this.element.prop("title", title);
   }
 
-  override click() {
+  click() {
     if (this.readOnly) {
       return;
     }
 
-    super.click();
+    this.requestRefresh();
+
+    return this.options?.onClick?.call(this);
   }
 
-  override refreshUi(): void {
-    super.refreshUi();
-
+  refreshUi(): void {
     if (this.readOnly) {
       this.element.addClass(styles.readonly);
     } else {

--- a/source/ui/components/ButtonListItem.ts
+++ b/source/ui/components/ButtonListItem.ts
@@ -10,19 +10,11 @@ export class ButtonListItem extends ListItem {
   readonly button: TextButton;
 
   constructor(parent: UiComponent, button: TextButton, options?: ButtonListItemOptions) {
-    super(parent, { ...options, children: [] });
+    super(parent, { ...options });
 
     this.button = button;
 
     this.element.addClass(stylesListItem.head);
     this.element.append(button.element);
-
-    this.addChildren(options?.children);
-  }
-
-  refreshUi(): void {
-    super.refreshUi();
-
-    this.button.refreshUi();
   }
 }

--- a/source/ui/components/ButtonListItem.ts
+++ b/source/ui/components/ButtonListItem.ts
@@ -1,16 +1,16 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
 import type { TextButton } from "./TextButton.js";
+import type { UiComponent } from "./UiComponent.js";
 
 export type ButtonListItemOptions = ThisType<ButtonListItem> & ListItemOptions;
 
 export class ButtonListItem extends ListItem {
-  declare readonly _options: ButtonListItemOptions;
+  declare readonly options: ButtonListItemOptions;
   readonly button: TextButton;
 
-  constructor(host: KittenScientists, button: TextButton, options?: ButtonListItemOptions) {
-    super(host, { ...options, children: [] });
+  constructor(parent: UiComponent, button: TextButton, options?: ButtonListItemOptions) {
+    super(parent, { ...options, children: [] });
 
     this.button = button;
 

--- a/source/ui/components/ButtonListItem.ts
+++ b/source/ui/components/ButtonListItem.ts
@@ -3,11 +3,13 @@ import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
 import type { TextButton } from "./TextButton.js";
 
+export type ButtonListItemOptions = ListItemOptions & ThisType<ButtonListItem>;
+
 export class ButtonListItem extends ListItem {
-  declare readonly _options: ListItemOptions;
+  declare readonly _options: ButtonListItemOptions;
   readonly button: TextButton;
 
-  constructor(host: KittenScientists, button: TextButton, options?: ListItemOptions) {
+  constructor(host: KittenScientists, button: TextButton, options?: ButtonListItemOptions) {
     super(host, { ...options, children: [] });
 
     this.button = button;

--- a/source/ui/components/ButtonListItem.ts
+++ b/source/ui/components/ButtonListItem.ts
@@ -3,7 +3,7 @@ import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
 import type { TextButton } from "./TextButton.js";
 
-export type ButtonListItemOptions = ListItemOptions & ThisType<ButtonListItem>;
+export type ButtonListItemOptions = ThisType<ButtonListItem> & ListItemOptions;
 
 export class ButtonListItem extends ListItem {
   declare readonly _options: ButtonListItemOptions;

--- a/source/ui/components/ButtonListItem.ts
+++ b/source/ui/components/ButtonListItem.ts
@@ -2,14 +2,12 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
 import type { TextButton } from "./TextButton.js";
-import type { UiComponent } from "./UiComponent.js";
 
-export class ButtonListItem<
-  TOptions extends ListItemOptions<UiComponent> = ListItemOptions<UiComponent>,
-> extends ListItem<TOptions> {
+export class ButtonListItem extends ListItem {
+  declare readonly _options: ListItemOptions;
   readonly button: TextButton;
 
-  constructor(host: KittenScientists, button: TextButton, options: Partial<TOptions> = {}) {
+  constructor(host: KittenScientists, button: TextButton, options?: ListItemOptions) {
     super(host, { ...options, children: [] });
 
     this.button = button;
@@ -17,7 +15,7 @@ export class ButtonListItem<
     this.element.addClass(stylesListItem.head);
     this.element.append(button.element);
 
-    this.addChildren(options.children);
+    this.addChildren(options?.children);
   }
 
   refreshUi(): void {

--- a/source/ui/components/CollapsiblePanel.ts
+++ b/source/ui/components/CollapsiblePanel.ts
@@ -3,14 +3,14 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import { Container } from "./Container.js";
 import type { LabelListItem } from "./LabelListItem.js";
 import stylesSettingListItem from "./SettingListItem.module.css";
-import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
+import { UiComponent, type UiComponentInterface, type UiComponentOptions } from "./UiComponent.js";
 import { ExpandoButton } from "./buttons/ExpandoButton.js";
 
-export type PanelOptions<TChild extends UiComponent = UiComponent> = UiComponentOptions<TChild> & {
+export type PanelOptions = UiComponentOptions & {
   /**
    * Should the main child be expanded right away?
    */
-  readonly initiallyExpanded: boolean;
+  readonly initiallyExpanded?: boolean;
 };
 
 /**
@@ -19,10 +19,8 @@ export type PanelOptions<TChild extends UiComponent = UiComponent> = UiComponent
  * The panel also has a head element, which is extended to create the panel
  * behavior.
  */
-export class CollapsiblePanel<
-  TOptions extends PanelOptions = PanelOptions,
-  THead extends LabelListItem = LabelListItem,
-> extends UiComponent<TOptions> {
+export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> extends UiComponent {
+  declare readonly _options: PanelOptions;
   protected readonly container: UiComponent;
   readonly element: JQuery;
   protected readonly _expando: ExpandoButton;
@@ -45,8 +43,8 @@ export class CollapsiblePanel<
    * @param head Another component to host in the head of the panel.
    * @param options Options for this panel.
    */
-  constructor(host: KittenScientists, head: THead, options?: Partial<TOptions>) {
-    super(host, options);
+  constructor(host: KittenScientists, head: THead, options?: PanelOptions) {
+    super(host, {});
 
     this.container = new Container(host);
     this.container.element.addClass(stylesSettingListItem.panelContent);
@@ -112,12 +110,12 @@ export class CollapsiblePanel<
     }
 
     if (toggleNested) {
-      const toggleChildren = (children: Set<TOptions["children"][0]>) => {
+      const toggleChildren = (children: Iterable<UiComponentInterface>) => {
         for (const child of children) {
-          if (is(child, CollapsiblePanel)) {
-            (child as CollapsiblePanel).toggle(expand, toggleNested);
+          if (is<CollapsiblePanel>(child, CollapsiblePanel)) {
+            child.toggle(expand, toggleNested);
           } else {
-            toggleChildren((child as UiComponent<TOptions>).children);
+            toggleChildren(child.children);
           }
         }
       };

--- a/source/ui/components/CollapsiblePanel.ts
+++ b/source/ui/components/CollapsiblePanel.ts
@@ -6,12 +6,12 @@ import stylesSettingListItem from "./SettingListItem.module.css";
 import { UiComponent, type UiComponentInterface, type UiComponentOptions } from "./UiComponent.js";
 import { ExpandoButton } from "./buttons/ExpandoButton.js";
 
-export type PanelOptions = UiComponentOptions & {
+export type CollapsiblePanelOptions = UiComponentOptions & {
   /**
    * Should the main child be expanded right away?
    */
   readonly initiallyExpanded?: boolean;
-};
+} & ThisType<CollapsiblePanel>;
 
 /**
  * A `Panel` is a section of the UI that can be expanded and collapsed
@@ -20,7 +20,7 @@ export type PanelOptions = UiComponentOptions & {
  * behavior.
  */
 export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> extends UiComponent {
-  declare readonly _options: PanelOptions;
+  declare readonly _options: CollapsiblePanelOptions;
   protected readonly container: UiComponent;
   readonly element: JQuery;
   protected readonly _expando: ExpandoButton;
@@ -43,7 +43,7 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
    * @param head Another component to host in the head of the panel.
    * @param options Options for this panel.
    */
-  constructor(host: KittenScientists, head: THead, options?: PanelOptions) {
+  constructor(host: KittenScientists, head: THead, options?: CollapsiblePanelOptions) {
     super(host, {});
 
     this.container = new Container(host);

--- a/source/ui/components/CollapsiblePanel.ts
+++ b/source/ui/components/CollapsiblePanel.ts
@@ -1,5 +1,4 @@
 import { is } from "@oliversalzburg/js-utils/data/nil.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import { Container } from "./Container.js";
 import type { LabelListItem } from "./LabelListItem.js";
 import stylesSettingListItem from "./SettingListItem.module.css";
@@ -21,13 +20,12 @@ export type CollapsiblePanelOptions = ThisType<CollapsiblePanel> &
  * behavior.
  */
 export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> extends UiComponent {
-  declare readonly _options: CollapsiblePanelOptions;
+  declare readonly options: CollapsiblePanelOptions;
   protected readonly container: UiComponent;
   readonly element: JQuery;
   protected readonly _expando: ExpandoButton;
   protected readonly _head: THead;
   protected _mainChildVisible: boolean;
-  protected readonly parent: CollapsiblePanel | undefined;
 
   get expando() {
     return this._expando;
@@ -44,10 +42,10 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
    * @param head Another component to host in the head of the panel.
    * @param options Options for this panel.
    */
-  constructor(host: KittenScientists, head: THead, options?: CollapsiblePanelOptions) {
-    super(host, {});
+  constructor(parent: UiComponent, head: THead, options?: CollapsiblePanelOptions) {
+    super(parent, {});
 
-    this.container = new Container(host);
+    this.container = new Container(parent);
     this.container.element.addClass(stylesSettingListItem.panelContent);
     this.children.add(this.container);
 
@@ -55,7 +53,7 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
     this.children.add(head);
 
     // The expando button for this panel.
-    const expando = new ExpandoButton(host);
+    const expando = new ExpandoButton(parent);
     expando.element.on("click", () => {
       this.toggle();
     });

--- a/source/ui/components/CollapsiblePanel.ts
+++ b/source/ui/components/CollapsiblePanel.ts
@@ -6,12 +6,13 @@ import stylesSettingListItem from "./SettingListItem.module.css";
 import { UiComponent, type UiComponentInterface, type UiComponentOptions } from "./UiComponent.js";
 import { ExpandoButton } from "./buttons/ExpandoButton.js";
 
-export type CollapsiblePanelOptions = UiComponentOptions & {
-  /**
-   * Should the main child be expanded right away?
-   */
-  readonly initiallyExpanded?: boolean;
-} & ThisType<CollapsiblePanel>;
+export type CollapsiblePanelOptions = ThisType<CollapsiblePanel> &
+  UiComponentOptions & {
+    /**
+     * Should the main child be expanded right away?
+     */
+    readonly initiallyExpanded?: boolean;
+  };
 
 /**
  * A `Panel` is a section of the UI that can be expanded and collapsed

--- a/source/ui/components/CollapsiblePanel.ts
+++ b/source/ui/components/CollapsiblePanel.ts
@@ -41,13 +41,9 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
   constructor(parent: UiComponent, head: THead, options?: CollapsiblePanelOptions) {
     super(parent, {});
 
+    this.head = head;
     this.container = new Container(this);
     this.container.element.addClass(stylesSettingListItem.panelContent);
-    this.children.add(this.container);
-
-    this.head = head;
-    this.children.add(head);
-    head.parent = this;
 
     // The expando button for this panel.
     const expando = new ExpandoButton(parent, {
@@ -67,16 +63,12 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
     this._mainChildVisible = options?.initiallyExpanded ?? false;
     this.element = head.element;
     this.expando = expando;
+
+    this.addChildren([this.head, this.container]);
   }
 
   toString(): string {
     return `[${CollapsiblePanel.name}#${this.componentId}]`;
-  }
-
-  override addChild(child: UiComponent): this {
-    this.children.add(child);
-    this.container.element.append(child.element);
-    return this;
   }
 
   addChildHead(child: UiComponentInterface): this {
@@ -86,6 +78,17 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
   addChildrenHead(children?: Iterable<UiComponentInterface>): this {
     for (const child of children ?? []) {
       this.head.addChild(child);
+    }
+    return this;
+  }
+
+  addChildContent(child: UiComponent): this {
+    this.container.addChild(child);
+    return this;
+  }
+  addChildrenContent(children?: Iterable<UiComponentInterface>): this {
+    for (const child of children ?? []) {
+      this.container.addChild(child);
     }
     return this;
   }
@@ -102,7 +105,7 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
       this._mainChildVisible = visible;
       if (this._mainChildVisible) {
         // Refresh panel UI on expand.
-        this.container.refreshUi();
+        this.container.requestRefresh();
         // Show the DOM element.
         this.container.element.removeClass(stylesSettingListItem.hidden);
         // Reflect expanded state on expando.
@@ -134,5 +137,5 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
     }
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/CollapsiblePanel.ts
+++ b/source/ui/components/CollapsiblePanel.ts
@@ -137,5 +137,10 @@ export class CollapsiblePanel<THead extends LabelListItem = LabelListItem> exten
     }
   }
 
+  requestRefresh(withChildren = false, depth = 0) {
+    super.requestRefresh(withChildren, depth);
+    this.head.requestRefresh(true, depth + 1);
+  }
+
   refreshUi(): void {}
 }

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -1,7 +1,11 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export class Container extends UiComponent {
+export type ContainerOptions = UiComponentOptions & {
+  readonly classes: Array<string>;
+};
+
+export class Container<TOptions extends ContainerOptions = ContainerOptions> extends UiComponent {
   readonly element: JQuery;
 
   /**
@@ -10,8 +14,8 @@ export class Container extends UiComponent {
    * @param host A reference to the host.
    * @param options Options for the container.
    */
-  constructor(host: KittenScientists, options?: Partial<UiComponentOptions>) {
-    super(host, { ...options, children: [], classes: [] });
+  constructor(host: KittenScientists, options?: Partial<TOptions>) {
+    super(host, { ...options, children: [] });
 
     this.element = $("<div/>");
 

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -1,9 +1,10 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type ContainerOptions = UiComponentOptions & {
-  readonly classes?: Array<string>;
-} & ThisType<Container>;
+export type ContainerOptions = ThisType<Container> &
+  UiComponentOptions & {
+    readonly classes?: Array<string>;
+  };
 
 export class Container extends UiComponent {
   declare readonly _options: ContainerOptions;

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -3,7 +3,7 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type ContainerOptions = UiComponentOptions & {
   readonly classes?: Array<string>;
-};
+} & ThisType<Container>;
 
 export class Container extends UiComponent {
   declare readonly _options: ContainerOptions;

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -6,6 +6,7 @@ export type ContainerOptions = UiComponentOptions & {
 };
 
 export class Container extends UiComponent {
+  declare readonly _options: ContainerOptions;
   readonly element: JQuery;
 
   /**

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -29,5 +29,5 @@ export class Container extends UiComponent {
     return `[${Container.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -2,10 +2,10 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type ContainerOptions = UiComponentOptions & {
-  readonly classes: Array<string>;
+  readonly classes?: Array<string>;
 };
 
-export class Container<TOptions extends ContainerOptions = ContainerOptions> extends UiComponent {
+export class Container extends UiComponent {
   readonly element: JQuery;
 
   /**
@@ -14,7 +14,7 @@ export class Container<TOptions extends ContainerOptions = ContainerOptions> ext
    * @param host A reference to the host.
    * @param options Options for the container.
    */
-  constructor(host: KittenScientists, options?: Partial<TOptions>) {
+  constructor(host: KittenScientists, options?: ContainerOptions) {
     super(host, { ...options, children: [] });
 
     this.element = $("<div/>");

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type ContainerOptions = ThisType<Container> &
@@ -7,7 +6,7 @@ export type ContainerOptions = ThisType<Container> &
   };
 
 export class Container extends UiComponent {
-  declare readonly _options: ContainerOptions;
+  declare readonly options: ContainerOptions;
   readonly element: JQuery;
 
   /**
@@ -16,8 +15,8 @@ export class Container extends UiComponent {
    * @param host A reference to the host.
    * @param options Options for the container.
    */
-  constructor(host: KittenScientists, options?: ContainerOptions) {
-    super(host, { ...options, children: [] });
+  constructor(parent: UiComponent, options?: ContainerOptions) {
+    super(parent, { ...options, children: [] });
 
     this.element = $("<div/>");
 

--- a/source/ui/components/Container.ts
+++ b/source/ui/components/Container.ts
@@ -16,14 +16,18 @@ export class Container extends UiComponent {
    * @param options Options for the container.
    */
   constructor(parent: UiComponent, options?: ContainerOptions) {
-    super(parent, { ...options, children: [] });
+    super(parent, { ...options });
 
     this.element = $("<div/>");
 
     for (const className of options?.classes ?? []) {
       this.element.addClass(className);
     }
-
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${Container.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/CyclesList.ts
+++ b/source/ui/components/CyclesList.ts
@@ -47,10 +47,14 @@ export class CyclesList extends SettingsList {
     const makeCycle = (cycle: Cycle, setting: Setting) => {
       const label = parent.host.engine.labelForCycle(cycle);
       return new SettingListItem(parent, setting, label, {
-        onCheck: (isBatchProcess?: boolean) =>
-          options?.onCheckCycle?.(label, setting, isBatchProcess),
-        onUnCheck: (isBatchProcess?: boolean) =>
-          options?.onUnCheckCycle?.(label, setting, isBatchProcess),
+        onCheck: (isBatchProcess?: boolean) => {
+          options?.onCheckCycle?.(label, setting, isBatchProcess);
+          this.requestRefresh();
+        },
+        onUnCheck: (isBatchProcess?: boolean) => {
+          options?.onUnCheckCycle?.(label, setting, isBatchProcess);
+          this.requestRefresh();
+        },
       });
     };
 
@@ -72,13 +76,13 @@ export class CyclesList extends SettingsList {
       for (const cycle of cycles) {
         cycle.check(true);
       }
-      this.refreshUi();
+      this.requestRefresh();
     });
     this.addEventListener("disableAll", () => {
       for (const cycle of cycles) {
         cycle.uncheck(true);
       }
-      this.refreshUi();
+      this.requestRefresh();
     });
   }
 }

--- a/source/ui/components/CyclesList.ts
+++ b/source/ui/components/CyclesList.ts
@@ -6,23 +6,24 @@ import { SettingsList, type SettingsListOptions } from "./SettingsList.js";
 
 export type SettingWithCycles = Record<Cycle, Setting>;
 
-export type CyclesListOptions = SettingsListOptions & {
-  /**
-   * Called when a cycle is checked.
-   *
-   * @param label The label on the cycle element.
-   * @param setting The setting associated with the cycle.
-   */
-  readonly onCheckCycle?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
+export type CyclesListOptions = ThisType<CyclesList> &
+  SettingsListOptions & {
+    /**
+     * Called when a cycle is checked.
+     *
+     * @param label The label on the cycle element.
+     * @param setting The setting associated with the cycle.
+     */
+    readonly onCheckCycle?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
 
-  /**
-   * Called when a cycle is unchecked.
-   *
-   * @param label The label on the cycle element.
-   * @param setting The setting associated with the cycle.
-   */
-  readonly onUnCheckCycle?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-} & ThisType<CyclesList>;
+    /**
+     * Called when a cycle is unchecked.
+     *
+     * @param label The label on the cycle element.
+     * @param setting The setting associated with the cycle.
+     */
+    readonly onUnCheckCycle?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
+  };
 
 /**
  * A list of settings correlating to the planetary cycles in the game.

--- a/source/ui/components/CyclesList.ts
+++ b/source/ui/components/CyclesList.ts
@@ -1,8 +1,8 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
 import type { Cycle } from "../../types/index.js";
 import { SettingListItem } from "./SettingListItem.js";
 import { SettingsList, type SettingsListOptions } from "./SettingsList.js";
+import type { UiComponent } from "./UiComponent.js";
 
 export type SettingWithCycles = Record<Cycle, Setting>;
 
@@ -29,7 +29,7 @@ export type CyclesListOptions = ThisType<CyclesList> &
  * A list of settings correlating to the planetary cycles in the game.
  */
 export class CyclesList extends SettingsList {
-  declare readonly _options: CyclesListOptions;
+  declare readonly options: CyclesListOptions;
   readonly setting: SettingWithCycles;
 
   /**
@@ -40,13 +40,13 @@ export class CyclesList extends SettingsList {
    * @param behavior Control cycle check box log output
    * @param options Options for this list.
    */
-  constructor(host: KittenScientists, setting: SettingWithCycles, options?: CyclesListOptions) {
-    super(host, options);
+  constructor(parent: UiComponent, setting: SettingWithCycles, options?: CyclesListOptions) {
+    super(parent, options);
     this.setting = setting;
 
     const makeCycle = (cycle: Cycle, setting: Setting) => {
-      const label = host.engine.labelForCycle(cycle);
-      return new SettingListItem(host, setting, label, {
+      const label = parent.host.engine.labelForCycle(cycle);
+      return new SettingListItem(parent, setting, label, {
         onCheck: (isBatchProcess?: boolean) =>
           options?.onCheckCycle?.(label, setting, isBatchProcess),
         onUnCheck: (isBatchProcess?: boolean) =>

--- a/source/ui/components/CyclesList.ts
+++ b/source/ui/components/CyclesList.ts
@@ -81,19 +81,4 @@ export class CyclesList extends SettingsList {
       this.refreshUi();
     });
   }
-
-  private _makeCycle(
-    cycle: Cycle,
-    setting: Setting,
-    handler?: Partial<{
-      onCheck: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-      onUnCheck: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-    }>,
-  ) {
-    const label = this._host.engine.labelForCycle(cycle);
-    return new SettingListItem(this._host, setting, label, {
-      onCheck: (isBatchProcess?: boolean) => handler?.onCheck?.(label, setting, isBatchProcess),
-      onUnCheck: (isBatchProcess?: boolean) => handler?.onUnCheck?.(label, setting, isBatchProcess),
-    });
-  }
 }

--- a/source/ui/components/CyclesList.ts
+++ b/source/ui/components/CyclesList.ts
@@ -28,6 +28,7 @@ export type SeasonsListOptions = SettingsListOptions & {
  * A list of settings correlating to the planetary cycles in the game.
  */
 export class CyclesList extends SettingsList {
+  declare readonly _options: SeasonsListOptions;
   readonly setting: SettingWithCycles;
 
   /**

--- a/source/ui/components/CyclesList.ts
+++ b/source/ui/components/CyclesList.ts
@@ -6,7 +6,7 @@ import { SettingsList, type SettingsListOptions } from "./SettingsList.js";
 
 export type SettingWithCycles = Record<Cycle, Setting>;
 
-export type SeasonsListOptions = SettingsListOptions & {
+export type CyclesListOptions = SettingsListOptions & {
   /**
    * Called when a cycle is checked.
    *
@@ -22,13 +22,13 @@ export type SeasonsListOptions = SettingsListOptions & {
    * @param setting The setting associated with the cycle.
    */
   readonly onUnCheckCycle?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-};
+} & ThisType<CyclesList>;
 
 /**
  * A list of settings correlating to the planetary cycles in the game.
  */
 export class CyclesList extends SettingsList {
-  declare readonly _options: SeasonsListOptions;
+  declare readonly _options: CyclesListOptions;
   readonly setting: SettingWithCycles;
 
   /**
@@ -39,7 +39,7 @@ export class CyclesList extends SettingsList {
    * @param behavior Control cycle check box log output
    * @param options Options for this list.
    */
-  constructor(host: KittenScientists, setting: SettingWithCycles, options?: SeasonsListOptions) {
+  constructor(host: KittenScientists, setting: SettingWithCycles, options?: CyclesListOptions) {
     super(host, options);
     this.setting = setting;
 

--- a/source/ui/components/Delimiter.ts
+++ b/source/ui/components/Delimiter.ts
@@ -22,5 +22,5 @@ export class Delimiter extends UiComponent {
     return `[${Delimiter.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/Delimiter.ts
+++ b/source/ui/components/Delimiter.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import styles from "./Delimiter.module.css";
 import { UiComponent } from "./UiComponent.js";
 
@@ -12,8 +11,8 @@ export class Delimiter extends UiComponent {
    * @param label The label on the fieldset.
    * @param options Options for the fieldset.
    */
-  constructor(host: KittenScientists) {
-    super(host, {});
+  constructor(parent: UiComponent) {
+    super(parent, {});
 
     const element = $("<div/>").addClass(styles.delimiter);
     this.element = element;

--- a/source/ui/components/Delimiter.ts
+++ b/source/ui/components/Delimiter.ts
@@ -17,4 +17,10 @@ export class Delimiter extends UiComponent {
     const element = $("<div/>").addClass(styles.delimiter);
     this.element = element;
   }
+
+  toString(): string {
+    return `[${Delimiter.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/Dialog.ts
+++ b/source/ui/components/Dialog.ts
@@ -1,5 +1,4 @@
 import { coalesceArray } from "@oliversalzburg/js-utils/data/nil.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import { Button } from "./Button.js";
 import stylesButton from "./Button.module.css";
 import { Container } from "./Container.js";
@@ -24,7 +23,7 @@ export type DialogOptions = ThisType<Dialog> &
   };
 
 export class Dialog extends UiComponent {
-  declare readonly _options: DialogOptions;
+  declare readonly options: DialogOptions;
   readonly element: JQuery<HTMLDialogElement>;
   returnValue: string;
 
@@ -34,8 +33,8 @@ export class Dialog extends UiComponent {
    * @param host - A reference to the host.
    * @param options - Options for the dialog.
    */
-  constructor(host: KittenScientists, options?: DialogOptions) {
-    super(host, { ...options, children: [] });
+  constructor(parent: UiComponent, options?: DialogOptions) {
+    super(parent, { ...options, children: [] });
 
     this.element = $<HTMLDialogElement>("<dialog/>")
       .addClass("dialog")
@@ -45,7 +44,7 @@ export class Dialog extends UiComponent {
 
     if (options?.hasClose !== false) {
       this.addChild(
-        new Button(host, "close", null, {
+        new Button(parent, "close", null, {
           classes: [styles.close],
           onClick: () => {
             this.close();
@@ -62,7 +61,7 @@ export class Dialog extends UiComponent {
     this.addChildren(
       coalesceArray([
         options?.prompt
-          ? new Input(host, {
+          ? new Input(parent, {
               onChange: (value: string) => {
                 this.returnValue = value;
               },
@@ -80,10 +79,10 @@ export class Dialog extends UiComponent {
             })
           : undefined,
         ...(options?.childrenAfterPrompt ?? []),
-        new Delimiter(host),
-        new Container(host, {
+        new Delimiter(parent),
+        new Container(parent, {
           children: coalesceArray([
-            new Button(host, "OK", null, {
+            new Button(parent, "OK", null, {
               classes: [stylesButton.large],
               onClick: () => {
                 this.close();
@@ -91,7 +90,7 @@ export class Dialog extends UiComponent {
               },
             }),
             options?.hasCancel
-              ? new Button(host, "Cancel", null, {
+              ? new Button(parent, "Cancel", null, {
                   classes: [stylesButton.large],
                   onClick: () => {
                     this.close();
@@ -120,22 +119,22 @@ export class Dialog extends UiComponent {
   }
 
   static async prompt(
-    host: KittenScientists,
+    parent: UiComponent,
     text: string,
     title?: string,
     initialValue?: string,
     explainer?: string,
   ): Promise<string | undefined> {
     return new Promise(resolve => {
-      new Dialog(host, {
+      new Dialog(parent, {
         children: coalesceArray([
-          title ? new HeaderListItem(host, title) : undefined,
-          new Paragraph(host, text),
+          title ? new HeaderListItem(parent, title) : undefined,
+          new Paragraph(parent, text),
         ]),
         childrenAfterPrompt: explainer
           ? [
-              new Container(host, {
-                children: [new Paragraph(host, explainer)],
+              new Container(parent, {
+                children: [new Paragraph(parent, explainer)],
                 classes: [stylesExplainer.explainer],
               }),
             ]

--- a/source/ui/components/Dialog.ts
+++ b/source/ui/components/Dialog.ts
@@ -12,15 +12,16 @@ import { Paragraph } from "./Paragraph.js";
 import stylesToolbarListItem from "./ToolbarListItem.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type DialogOptions = UiComponentOptions & {
-  readonly hasCancel?: boolean;
-  readonly hasClose?: boolean;
-  readonly onCancel?: () => void;
-  readonly onConfirm?: (result: string) => void;
-  readonly prompt?: boolean;
-  readonly promptValue?: string;
-  readonly childrenAfterPrompt?: Array<UiComponent>;
-} & ThisType<Dialog>;
+export type DialogOptions = ThisType<Dialog> &
+  UiComponentOptions & {
+    readonly hasCancel?: boolean;
+    readonly hasClose?: boolean;
+    readonly onCancel?: () => void;
+    readonly onConfirm?: (result: string) => void;
+    readonly prompt?: boolean;
+    readonly promptValue?: string;
+    readonly childrenAfterPrompt?: Array<UiComponent>;
+  };
 
 export class Dialog extends UiComponent {
   declare readonly _options: DialogOptions;

--- a/source/ui/components/Dialog.ts
+++ b/source/ui/components/Dialog.ts
@@ -23,6 +23,7 @@ export type DialogOptions = UiComponentOptions & {
 };
 
 export class Dialog extends UiComponent {
+  declare readonly _options: DialogOptions;
   readonly element: JQuery<HTMLDialogElement>;
   returnValue: string;
 

--- a/source/ui/components/Dialog.ts
+++ b/source/ui/components/Dialog.ts
@@ -147,7 +147,7 @@ export class Dialog extends UiComponent {
     this.element.remove();
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 
   static async prompt(
     parent: UiComponent,

--- a/source/ui/components/Dialog.ts
+++ b/source/ui/components/Dialog.ts
@@ -20,7 +20,7 @@ export type DialogOptions = UiComponentOptions & {
   readonly prompt?: boolean;
   readonly promptValue?: string;
   readonly childrenAfterPrompt?: Array<UiComponent>;
-};
+} & ThisType<Dialog>;
 
 export class Dialog extends UiComponent {
   declare readonly _options: DialogOptions;

--- a/source/ui/components/Dialog.ts
+++ b/source/ui/components/Dialog.ts
@@ -32,7 +32,7 @@ export class Dialog extends UiComponent {
    * @param host - A reference to the host.
    * @param options - Options for the dialog.
    */
-  constructor(host: KittenScientists, options?: Partial<DialogOptions>) {
+  constructor(host: KittenScientists, options?: DialogOptions) {
     super(host, { ...options, children: [] });
 
     this.element = $<HTMLDialogElement>("<dialog/>")

--- a/source/ui/components/ExplainerListItem.ts
+++ b/source/ui/components/ExplainerListItem.ts
@@ -1,5 +1,4 @@
 import type { TranslatedString } from "../../Engine.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import styles from "./ExplainerLiteItem.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
@@ -7,7 +6,7 @@ export type ExplainerListItemOptions<TKittenGameLiteral extends `$${string}`> = 
   ThisType<ExplainerListItem<TKittenGameLiteral>>;
 
 export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends UiComponent {
-  declare readonly _options: ExplainerListItemOptions<TKittenGameLiteral>;
+  declare readonly options: ExplainerListItemOptions<TKittenGameLiteral>;
   readonly element: JQuery;
 
   /**
@@ -19,13 +18,13 @@ export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends 
    * @param options - Options for this explainer.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     key: TranslatedString<TKittenGameLiteral>,
     options?: ExplainerListItemOptions<TKittenGameLiteral>,
   ) {
-    super(host, { ...options });
+    super(parent, { ...options });
 
-    const element = $("<li/>", { text: host.engine.i18n(key) }).addClass(styles.explainer);
+    const element = $("<li/>", { text: parent.host.engine.i18n(key) }).addClass(styles.explainer);
 
     this.element = element;
     this.addChildren(options?.children);

--- a/source/ui/components/ExplainerListItem.ts
+++ b/source/ui/components/ExplainerListItem.ts
@@ -3,7 +3,11 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import styles from "./ExplainerLiteItem.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
+export type ExplainerListItemOptions<TKittenGameLiteral extends `$${string}`> = UiComponentOptions &
+  ThisType<ExplainerListItem<TKittenGameLiteral>>;
+
 export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends UiComponent {
+  declare readonly _options: ExplainerListItemOptions<TKittenGameLiteral>;
   readonly element: JQuery;
 
   /**
@@ -17,7 +21,7 @@ export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends 
   constructor(
     host: KittenScientists,
     key: TranslatedString<TKittenGameLiteral>,
-    options?: UiComponentOptions,
+    options?: ExplainerListItemOptions<TKittenGameLiteral>,
   ) {
     super(host, { ...options });
 

--- a/source/ui/components/ExplainerListItem.ts
+++ b/source/ui/components/ExplainerListItem.ts
@@ -19,7 +19,7 @@ export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends 
     key: TranslatedString<TKittenGameLiteral>,
     options?: Partial<UiComponentOptions>,
   ) {
-    super(host);
+    super(host, { ...options });
 
     const element = $("<li/>", { text: host.engine.i18n(key) }).addClass(styles.explainer);
 

--- a/source/ui/components/ExplainerListItem.ts
+++ b/source/ui/components/ExplainerListItem.ts
@@ -27,6 +27,11 @@ export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends 
     const element = $("<li/>", { text: parent.host.engine.i18n(key) }).addClass(styles.explainer);
 
     this.element = element;
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${ExplainerListItem.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/ExplainerListItem.ts
+++ b/source/ui/components/ExplainerListItem.ts
@@ -17,7 +17,7 @@ export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends 
   constructor(
     host: KittenScientists,
     key: TranslatedString<TKittenGameLiteral>,
-    options?: Partial<UiComponentOptions>,
+    options?: UiComponentOptions,
   ) {
     super(host, { ...options });
 

--- a/source/ui/components/ExplainerListItem.ts
+++ b/source/ui/components/ExplainerListItem.ts
@@ -33,5 +33,5 @@ export class ExplainerListItem<TKittenGameLiteral extends `$${string}`> extends 
     return `[${ExplainerListItem.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -5,7 +5,7 @@ import stylesLabel from "./LabelListItem.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type FieldsetOptions = UiComponentOptions & {
-  readonly delimiter: boolean;
+  readonly delimiter?: boolean;
 };
 
 export class Fieldset extends UiComponent {
@@ -18,8 +18,8 @@ export class Fieldset extends UiComponent {
    * @param label The label on the fieldset.
    * @param options Options for the fieldset.
    */
-  constructor(host: KittenScientists, label: string, options?: Partial<FieldsetOptions>) {
-    super(host, options);
+  constructor(host: KittenScientists, label: string, options?: FieldsetOptions) {
+    super(host, { ...options });
 
     const element = $("<fieldset/>").addClass(styles.fieldset);
     if (options?.delimiter) {

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -30,6 +30,11 @@ export class Fieldset extends UiComponent {
     element.append(legend);
 
     this.element = element;
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${Fieldset.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -6,7 +6,7 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type FieldsetOptions = UiComponentOptions & {
   readonly delimiter?: boolean;
-};
+} & ThisType<Fieldset>;
 
 export class Fieldset extends UiComponent {
   declare readonly _options: FieldsetOptions;

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -4,9 +4,10 @@ import styles from "./Fieldset.module.css";
 import stylesLabel from "./LabelListItem.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type FieldsetOptions = UiComponentOptions & {
-  readonly delimiter?: boolean;
-} & ThisType<Fieldset>;
+export type FieldsetOptions = ThisType<Fieldset> &
+  UiComponentOptions & {
+    readonly delimiter?: boolean;
+  };
 
 export class Fieldset extends UiComponent {
   declare readonly _options: FieldsetOptions;

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import stylesDelimiter from "./Delimiter.module.css";
 import styles from "./Fieldset.module.css";
 import stylesLabel from "./LabelListItem.module.css";
@@ -10,7 +9,7 @@ export type FieldsetOptions = ThisType<Fieldset> &
   };
 
 export class Fieldset extends UiComponent {
-  declare readonly _options: FieldsetOptions;
+  declare readonly options: FieldsetOptions;
   readonly element: JQuery;
 
   /**
@@ -20,8 +19,8 @@ export class Fieldset extends UiComponent {
    * @param label The label on the fieldset.
    * @param options Options for the fieldset.
    */
-  constructor(host: KittenScientists, label: string, options?: FieldsetOptions) {
-    super(host, { ...options });
+  constructor(parent: UiComponent, label: string, options?: FieldsetOptions) {
+    super(parent, { ...options });
 
     const element = $("<fieldset/>").addClass(styles.fieldset);
     if (options?.delimiter) {

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -36,5 +36,5 @@ export class Fieldset extends UiComponent {
     return `[${Fieldset.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/Fieldset.ts
+++ b/source/ui/components/Fieldset.ts
@@ -9,6 +9,7 @@ export type FieldsetOptions = UiComponentOptions & {
 };
 
 export class Fieldset extends UiComponent {
+  declare readonly _options: FieldsetOptions;
   readonly element: JQuery;
 
   /**

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -3,6 +3,8 @@ import styles from "./HeaderListItem.module.css";
 import type { ListItem, ListItemOptions } from "./ListItem.js";
 import { UiComponent } from "./UiComponent.js";
 
+export type HeaderListItemOptions = ListItemOptions & ThisType<HeaderListItem>;
+
 export class HeaderListItem extends UiComponent implements ListItem {
   declare readonly _options: ListItemOptions;
   readonly element: JQuery;

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -3,7 +3,7 @@ import styles from "./HeaderListItem.module.css";
 import type { ListItem, ListItemOptions } from "./ListItem.js";
 import { UiComponent } from "./UiComponent.js";
 
-export type HeaderListItemOptions = ListItemOptions & ThisType<HeaderListItem>;
+export type HeaderListItemOptions = ThisType<HeaderListItem> & ListItemOptions;
 
 export class HeaderListItem extends UiComponent implements ListItem {
   declare readonly _options: ListItemOptions;

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -28,7 +28,7 @@ export class HeaderListItem extends UiComponent implements ListItem {
   }
 
   toString(): string {
-    return `[${HeaderListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${HeaderListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 
   refreshUi(): void {}

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -31,5 +31,5 @@ export class HeaderListItem extends UiComponent implements ListItem {
     return `[${HeaderListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -25,6 +25,11 @@ export class HeaderListItem extends UiComponent implements ListItem {
     const element = $("<li/>", { text }).addClass(styles.header);
 
     this.element = element;
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${HeaderListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -3,12 +3,8 @@ import styles from "./HeaderListItem.module.css";
 import type { ListItem, ListItemOptions } from "./ListItem.js";
 import { UiComponent } from "./UiComponent.js";
 
-export class HeaderListItem<
-    TOptions extends ListItemOptions<UiComponent> = ListItemOptions<UiComponent>,
-  >
-  extends UiComponent<TOptions>
-  implements ListItem<TOptions>
-{
+export class HeaderListItem extends UiComponent implements ListItem {
+  declare readonly _options: ListItemOptions;
   readonly element: JQuery;
   get elementLabel() {
     return this.element;
@@ -22,8 +18,8 @@ export class HeaderListItem<
    * @param text The text to appear on the header element.
    * @param options Options for the header.
    */
-  constructor(host: KittenScientists, text: string, options?: Partial<TOptions>) {
-    super(host, options);
+  constructor(host: KittenScientists, text: string, options?: ListItemOptions) {
+    super(host, { ...options });
 
     const element = $("<li/>", { text }).addClass(styles.header);
 

--- a/source/ui/components/HeaderListItem.ts
+++ b/source/ui/components/HeaderListItem.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import styles from "./HeaderListItem.module.css";
 import type { ListItem, ListItemOptions } from "./ListItem.js";
 import { UiComponent } from "./UiComponent.js";
@@ -6,7 +5,7 @@ import { UiComponent } from "./UiComponent.js";
 export type HeaderListItemOptions = ThisType<HeaderListItem> & ListItemOptions;
 
 export class HeaderListItem extends UiComponent implements ListItem {
-  declare readonly _options: ListItemOptions;
+  declare readonly options: ListItemOptions;
   readonly element: JQuery;
   get elementLabel() {
     return this.element;
@@ -20,8 +19,8 @@ export class HeaderListItem extends UiComponent implements ListItem {
    * @param text The text to appear on the header element.
    * @param options Options for the header.
    */
-  constructor(host: KittenScientists, text: string, options?: ListItemOptions) {
-    super(host, { ...options });
+  constructor(parent: UiComponent, text: string, options?: ListItemOptions) {
+    super(parent, { ...options });
 
     const element = $("<li/>", { text }).addClass(styles.header);
 

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -5,6 +5,7 @@ export type IconButtonOptions = ThisType<IconButton> &
   UiComponentOptions & {
     readonly readOnly?: boolean;
     readonly inactive?: boolean;
+    readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
   };
 
 /**
@@ -33,7 +34,6 @@ export class IconButton extends UiComponent {
     }).addClass(stylesButton.iconButton);
 
     this.element = element;
-    this.addChildren(options?.children);
     this.readOnly = options?.readOnly ?? false;
     this.inactive = options?.inactive ?? false;
 
@@ -42,17 +42,19 @@ export class IconButton extends UiComponent {
     });
   }
 
-  override click() {
+  toString(): string {
+    return `[${IconButton.name}#${this.componentId}]`;
+  }
+
+  click() {
     if (this.readOnly) {
       return;
     }
 
-    super.click();
+    return this.options?.onClick?.call(this);
   }
 
   override refreshUi(): void {
-    super.refreshUi();
-
     if (this.readOnly) {
       this.element.addClass(stylesButton.readonly);
     } else {

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -2,10 +2,11 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import stylesButton from "./Button.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type IconButtonOptions = UiComponentOptions & {
-  readonly readOnly?: boolean;
-  readonly inactive?: boolean;
-} & ThisType<IconButton>;
+export type IconButtonOptions = ThisType<IconButton> &
+  UiComponentOptions & {
+    readonly readOnly?: boolean;
+    readonly inactive?: boolean;
+  };
 
 /**
  * A button that is visually represented through an SVG element.

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -54,7 +54,7 @@ export class IconButton extends UiComponent {
     return this.options?.onClick?.call(this);
   }
 
-  override refreshUi(): void {
+  refreshUi(): void {
     if (this.readOnly) {
       this.element.addClass(stylesButton.readonly);
     } else {

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import stylesButton from "./Button.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
@@ -12,7 +11,7 @@ export type IconButtonOptions = ThisType<IconButton> &
  * A button that is visually represented through an SVG element.
  */
 export class IconButton extends UiComponent {
-  declare readonly _options: IconButtonOptions;
+  declare readonly options: IconButtonOptions;
   readonly element: JQuery;
   readOnly: boolean;
   inactive: boolean;
@@ -25,13 +24,8 @@ export class IconButton extends UiComponent {
    * @param title The `title` of the element.
    * @param options Options for the icon button.
    */
-  constructor(
-    host: KittenScientists,
-    pathData: string,
-    title: string,
-    options?: IconButtonOptions,
-  ) {
-    super(host, { ...options });
+  constructor(parent: UiComponent, pathData: string, title: string, options?: IconButtonOptions) {
+    super(parent, { ...options });
 
     const element = $("<div/>", {
       html: `<svg style="width: 18px; height: 18px;" viewBox="0 -960 960 960" fill="currentColor"><path d="${pathData}"/></svg>`,

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -3,14 +3,15 @@ import stylesButton from "./Button.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type IconButtonOptions = UiComponentOptions & {
-  readonly readOnly: boolean;
-  readonly inactive: boolean;
+  readonly readOnly?: boolean;
+  readonly inactive?: boolean;
 };
 
 /**
  * A button that is visually represented through an SVG element.
  */
 export class IconButton extends UiComponent {
+  declare readonly _options: IconButtonOptions;
   readonly element: JQuery;
   readOnly: boolean;
   inactive: boolean;
@@ -27,9 +28,9 @@ export class IconButton extends UiComponent {
     host: KittenScientists,
     pathData: string,
     title: string,
-    options?: Partial<IconButtonOptions>,
+    options?: IconButtonOptions,
   ) {
-    super(host, options);
+    super(host, { ...options });
 
     const element = $("<div/>", {
       html: `<svg style="width: 18px; height: 18px;" viewBox="0 -960 960 960" fill="currentColor"><path d="${pathData}"/></svg>`,

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -5,7 +5,7 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 export type IconButtonOptions = UiComponentOptions & {
   readonly readOnly?: boolean;
   readonly inactive?: boolean;
-};
+} & ThisType<IconButton>;
 
 /**
  * A button that is visually represented through an SVG element.

--- a/source/ui/components/IconButton.ts
+++ b/source/ui/components/IconButton.ts
@@ -5,7 +5,7 @@ export type IconButtonOptions = ThisType<IconButton> &
   UiComponentOptions & {
     readonly readOnly?: boolean;
     readonly inactive?: boolean;
-    readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
+    readonly onClick: (event?: MouseEvent) => void | Promise<void>;
   };
 
 /**

--- a/source/ui/components/IconSettingsPanel.ts
+++ b/source/ui/components/IconSettingsPanel.ts
@@ -1,7 +1,7 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
 import { CollapsiblePanel, type CollapsiblePanelOptions } from "./CollapsiblePanel.js";
 import { LabelListItem, type LabelListItemOptions } from "./LabelListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 
 export type IconSettingsPanelOptions = ThisType<IconSettingsPanel> &
   LabelListItemOptions &
@@ -13,7 +13,7 @@ export type IconSettingsPanelOptions = ThisType<IconSettingsPanel> &
   };
 
 export class IconSettingsPanel<TSetting extends Setting = Setting> extends CollapsiblePanel {
-  declare readonly _options: IconSettingsPanelOptions;
+  declare readonly options: IconSettingsPanelOptions;
   readonly setting: TSetting;
 
   /**
@@ -25,14 +25,17 @@ export class IconSettingsPanel<TSetting extends Setting = Setting> extends Colla
    * @param options Options for the panel.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     label: string,
     setting: TSetting,
     options?: IconSettingsPanelOptions,
   ) {
     super(
-      host,
-      new LabelListItem(host, label, { childrenHead: options?.childrenHead, icon: options?.icon }),
+      parent,
+      new LabelListItem(parent, label, {
+        childrenHead: options?.childrenHead,
+        icon: options?.icon,
+      }),
       {
         initiallyExpanded: options?.initiallyExpanded,
       },

--- a/source/ui/components/IconSettingsPanel.ts
+++ b/source/ui/components/IconSettingsPanel.ts
@@ -33,7 +33,6 @@ export class IconSettingsPanel<TSetting extends Setting = Setting> extends Colla
     super(
       parent,
       new LabelListItem(parent, label, {
-        childrenHead: options?.childrenHead,
         icon: options?.icon,
       }),
       {

--- a/source/ui/components/IconSettingsPanel.ts
+++ b/source/ui/components/IconSettingsPanel.ts
@@ -1,15 +1,15 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
-import { CollapsiblePanel, type PanelOptions } from "./CollapsiblePanel.js";
+import { CollapsiblePanel, type CollapsiblePanelOptions } from "./CollapsiblePanel.js";
 import { LabelListItem, type LabelListItemOptions } from "./LabelListItem.js";
 
 export type IconSettingsPanelOptions = LabelListItemOptions &
-  PanelOptions & {
+  CollapsiblePanelOptions & {
     /**
      * When set to an SVG path, will be used as an icon on the panel.
      */
     readonly icon: string;
-  };
+  } & ThisType<IconSettingsPanel>;
 
 export class IconSettingsPanel<TSetting extends Setting = Setting> extends CollapsiblePanel {
   declare readonly _options: IconSettingsPanelOptions;

--- a/source/ui/components/IconSettingsPanel.ts
+++ b/source/ui/components/IconSettingsPanel.ts
@@ -26,7 +26,7 @@ export class IconSettingsPanel<TSetting extends Setting = Setting> extends Colla
     host: KittenScientists,
     label: string,
     setting: TSetting,
-    options?: Partial<IconSettingsPanelOptions>,
+    options?: IconSettingsPanelOptions,
   ) {
     super(
       host,

--- a/source/ui/components/IconSettingsPanel.ts
+++ b/source/ui/components/IconSettingsPanel.ts
@@ -3,13 +3,14 @@ import type { Setting } from "../../settings/Settings.js";
 import { CollapsiblePanel, type CollapsiblePanelOptions } from "./CollapsiblePanel.js";
 import { LabelListItem, type LabelListItemOptions } from "./LabelListItem.js";
 
-export type IconSettingsPanelOptions = LabelListItemOptions &
+export type IconSettingsPanelOptions = ThisType<IconSettingsPanel> &
+  LabelListItemOptions &
   CollapsiblePanelOptions & {
     /**
      * When set to an SVG path, will be used as an icon on the panel.
      */
     readonly icon: string;
-  } & ThisType<IconSettingsPanel>;
+  };
 
 export class IconSettingsPanel<TSetting extends Setting = Setting> extends CollapsiblePanel {
   declare readonly _options: IconSettingsPanelOptions;

--- a/source/ui/components/IconSettingsPanel.ts
+++ b/source/ui/components/IconSettingsPanel.ts
@@ -12,6 +12,7 @@ export type IconSettingsPanelOptions = LabelListItemOptions &
   };
 
 export class IconSettingsPanel<TSetting extends Setting = Setting> extends CollapsiblePanel {
+  declare readonly _options: IconSettingsPanelOptions;
   readonly setting: TSetting;
 
   /**

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -2,14 +2,15 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type InputOptions = UiComponentOptions & {
-  readonly onChange?: (value: string) => void;
-  readonly onEnter?: (currentValue: string) => void;
-  readonly onEscape?: (currentValue: string) => void;
-  readonly selected?: boolean;
-  readonly value?: string;
+  readonly onChange: (value: string) => void;
+  readonly onEnter: (currentValue: string) => void;
+  readonly onEscape: (currentValue: string) => void;
+  readonly selected: boolean;
+  readonly value: string;
+  readonly classes: Array<string>;
 };
 
-export class Input extends UiComponent {
+export class Input<TOptions extends InputOptions> extends UiComponent {
   readonly element: JQuery<HTMLInputElement>;
 
   /**
@@ -19,8 +20,8 @@ export class Input extends UiComponent {
    * @param label - The label on the input element.
    * @param options - Options for the UI element.
    */
-  constructor(host: KittenScientists, options?: Partial<InputOptions>) {
-    super(host, { ...options, children: [], classes: [] });
+  constructor(host: KittenScientists, options?: Partial<TOptions>) {
+    super(host, { ...options, children: [] });
 
     this.element = $<HTMLInputElement>('<input type="text"/>').addClass("ks-input");
 

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -8,7 +8,7 @@ export type InputOptions = UiComponentOptions & {
   readonly selected?: boolean;
   readonly value?: string;
   readonly classes?: Array<string>;
-};
+} & ThisType<Input>;
 
 export class Input extends UiComponent {
   declare readonly _options: InputOptions;

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -22,7 +22,7 @@ export class Input extends UiComponent {
    * @param options - Options for the UI element.
    */
   constructor(parent: UiComponent, options?: InputOptions) {
-    super(parent, { ...options, children: [] });
+    super(parent, { ...options });
 
     this.element = $<HTMLInputElement>('<input type="text"/>').addClass("ks-input");
 
@@ -53,7 +53,11 @@ export class Input extends UiComponent {
           break;
       }
     });
-
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${Input.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -1,14 +1,15 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type InputOptions = UiComponentOptions & {
-  readonly onChange?: (value: string) => void;
-  readonly onEnter?: (currentValue: string) => void;
-  readonly onEscape?: (currentValue: string) => void;
-  readonly selected?: boolean;
-  readonly value?: string;
-  readonly classes?: Array<string>;
-} & ThisType<Input>;
+export type InputOptions = ThisType<Input> &
+  UiComponentOptions & {
+    readonly onChange?: (value: string) => void;
+    readonly onEnter?: (currentValue: string) => void;
+    readonly onEscape?: (currentValue: string) => void;
+    readonly selected?: boolean;
+    readonly value?: string;
+    readonly classes?: Array<string>;
+  };
 
 export class Input extends UiComponent {
   declare readonly _options: InputOptions;

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -11,6 +11,7 @@ export type InputOptions = UiComponentOptions & {
 };
 
 export class Input extends UiComponent {
+  declare readonly _options: InputOptions;
   readonly element: JQuery<HTMLInputElement>;
 
   /**

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type InputOptions = ThisType<Input> &
@@ -12,7 +11,7 @@ export type InputOptions = ThisType<Input> &
   };
 
 export class Input extends UiComponent {
-  declare readonly _options: InputOptions;
+  declare readonly options: InputOptions;
   readonly element: JQuery<HTMLInputElement>;
 
   /**
@@ -22,8 +21,8 @@ export class Input extends UiComponent {
    * @param label - The label on the input element.
    * @param options - Options for the UI element.
    */
-  constructor(host: KittenScientists, options?: InputOptions) {
-    super(host, { ...options, children: [] });
+  constructor(parent: UiComponent, options?: InputOptions) {
+    super(parent, { ...options, children: [] });
 
     this.element = $<HTMLInputElement>('<input type="text"/>').addClass("ks-input");
 

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -59,5 +59,5 @@ export class Input extends UiComponent {
     return `[${Input.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/Input.ts
+++ b/source/ui/components/Input.ts
@@ -2,15 +2,15 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type InputOptions = UiComponentOptions & {
-  readonly onChange: (value: string) => void;
-  readonly onEnter: (currentValue: string) => void;
-  readonly onEscape: (currentValue: string) => void;
-  readonly selected: boolean;
-  readonly value: string;
-  readonly classes: Array<string>;
+  readonly onChange?: (value: string) => void;
+  readonly onEnter?: (currentValue: string) => void;
+  readonly onEscape?: (currentValue: string) => void;
+  readonly selected?: boolean;
+  readonly value?: string;
+  readonly classes?: Array<string>;
 };
 
-export class Input<TOptions extends InputOptions> extends UiComponent {
+export class Input extends UiComponent {
   readonly element: JQuery<HTMLInputElement>;
 
   /**
@@ -20,7 +20,7 @@ export class Input<TOptions extends InputOptions> extends UiComponent {
    * @param label - The label on the input element.
    * @param options - Options for the UI element.
    */
-  constructor(host: KittenScientists, options?: Partial<TOptions>) {
+  constructor(host: KittenScientists, options?: InputOptions) {
     super(host, { ...options, children: [] });
 
     this.element = $<HTMLInputElement>('<input type="text"/>').addClass("ks-input");

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import { Container } from "./Container.js";
 import styles from "./LabelListItem.module.css";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
@@ -22,7 +21,7 @@ export type LabelListItemOptions = ThisType<LabelListItem> &
   };
 
 export class LabelListItem extends ListItem {
-  declare readonly _options: LabelListItemOptions;
+  declare readonly options: LabelListItemOptions;
   readonly head: Container;
   readonly elementLabel: JQuery;
 
@@ -33,10 +32,10 @@ export class LabelListItem extends ListItem {
    * @param label The label on the setting element.
    * @param options Options for the list item.
    */
-  constructor(host: KittenScientists, label: string, options?: LabelListItemOptions) {
-    super(host, options);
+  constructor(parent: UiComponent, label: string, options?: LabelListItemOptions) {
+    super(parent, options);
 
-    this.head = new Container(host);
+    this.head = new Container(parent);
     this.head.element.addClass(stylesListItem.head);
     this.addChild(this.head);
 

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -66,4 +66,9 @@ export class LabelListItem extends ListItem {
     }
     return this;
   }
+
+  requestRefresh(withChildren = false, depth = 0) {
+    super.requestRefresh(withChildren, depth);
+    this.head.requestRefresh(true, depth + 1);
+  }
 }

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -5,20 +5,21 @@ import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
 import type { UiComponent } from "./UiComponent.js";
 
-export type LabelListItemOptions = ListItemOptions & {
-  readonly childrenHead?: Array<UiComponent>;
+export type LabelListItemOptions = ThisType<LabelListItem> &
+  ListItemOptions & {
+    readonly childrenHead?: Array<UiComponent>;
 
-  /**
-   * When set to an SVG path, will be used as an icon on the label.
-   */
-  readonly icon?: string;
+    /**
+     * When set to an SVG path, will be used as an icon on the label.
+     */
+    readonly icon?: string;
 
-  /**
-   * Should an indicator be rendered in front of the element,
-   * to indicate that this is an upgrade of a prior setting?
-   */
-  readonly upgradeIndicator?: boolean;
-} & ThisType<LabelListItem>;
+    /**
+     * Should an indicator be rendered in front of the element,
+     * to indicate that this is an upgrade of a prior setting?
+     */
+    readonly upgradeIndicator?: boolean;
+  };
 
 export class LabelListItem extends ListItem {
   declare readonly _options: LabelListItemOptions;

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -2,12 +2,10 @@ import { Container } from "./Container.js";
 import styles from "./LabelListItem.module.css";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
-import type { UiComponent } from "./UiComponent.js";
+import type { UiComponent, UiComponentInterface } from "./UiComponent.js";
 
 export type LabelListItemOptions = ThisType<LabelListItem> &
   ListItemOptions & {
-    readonly childrenHead?: Array<UiComponent>;
-
     /**
      * When set to an SVG path, will be used as an icon on the label.
      */
@@ -43,15 +41,8 @@ export class LabelListItem extends ListItem {
       text: `${options?.upgradeIndicator === true ? "⮤ " : ""}${label}`,
     })
       .addClass(styles.label)
-      .addClass(stylesListItem.label)
-      .on("click", () => {
-        this.click();
-      });
+      .addClass(stylesListItem.label);
     this.head.element.append(this.elementLabel);
-
-    for (const child of options?.childrenHead ?? []) {
-      this.head.addChild(child);
-    }
 
     if (options?.icon) {
       const iconElement = $("<div/>", {
@@ -59,5 +50,20 @@ export class LabelListItem extends ListItem {
       }).addClass(styles.iconLabel);
       this.elementLabel.prepend(iconElement);
     }
+  }
+
+  toString(): string {
+    return `[${LabelListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+  }
+
+  addChildHead(child: UiComponentInterface): this {
+    this.head.addChild(child);
+    return this;
+  }
+  addChildrenHead(children?: Iterable<UiComponentInterface>): this {
+    for (const child of children ?? []) {
+      this.head.addChild(child);
+    }
+    return this;
   }
 }

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -21,6 +21,7 @@ export type LabelListItemOptions = ListItemOptions & {
 };
 
 export class LabelListItem extends ListItem {
+  declare readonly _options: LabelListItemOptions;
   readonly head: Container;
   readonly elementLabel: JQuery;
 

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -53,7 +53,7 @@ export class LabelListItem extends ListItem {
   }
 
   toString(): string {
-    return `[${LabelListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${LabelListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 
   addChildHead(child: UiComponentInterface): this {

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -18,7 +18,7 @@ export type LabelListItemOptions = ListItemOptions & {
    * to indicate that this is an upgrade of a prior setting?
    */
   readonly upgradeIndicator?: boolean;
-};
+} & ThisType<LabelListItem>;
 
 export class LabelListItem extends ListItem {
   declare readonly _options: LabelListItemOptions;

--- a/source/ui/components/LabelListItem.ts
+++ b/source/ui/components/LabelListItem.ts
@@ -3,27 +3,24 @@ import { Container } from "./Container.js";
 import styles from "./LabelListItem.module.css";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import stylesListItem from "./ListItem.module.css";
-import type { UiComponent, UiComponentInterface } from "./UiComponent.js";
+import type { UiComponent } from "./UiComponent.js";
 
-export type LabelListItemOptions<TChild extends UiComponentInterface = UiComponentInterface> =
-  ListItemOptions<TChild> & {
-    readonly childrenHead: Array<UiComponent>;
+export type LabelListItemOptions = ListItemOptions & {
+  readonly childrenHead?: Array<UiComponent>;
 
-    /**
-     * When set to an SVG path, will be used as an icon on the label.
-     */
-    readonly icon: string;
+  /**
+   * When set to an SVG path, will be used as an icon on the label.
+   */
+  readonly icon?: string;
 
-    /**
-     * Should an indicator be rendered in front of the element,
-     * to indicate that this is an upgrade of a prior setting?
-     */
-    readonly upgradeIndicator: boolean;
-  };
+  /**
+   * Should an indicator be rendered in front of the element,
+   * to indicate that this is an upgrade of a prior setting?
+   */
+  readonly upgradeIndicator?: boolean;
+};
 
-export class LabelListItem<
-  TOptions extends LabelListItemOptions<UiComponent> = LabelListItemOptions<UiComponent>,
-> extends ListItem<TOptions> {
+export class LabelListItem extends ListItem {
   readonly head: Container;
   readonly elementLabel: JQuery;
 
@@ -34,7 +31,7 @@ export class LabelListItem<
    * @param label The label on the setting element.
    * @param options Options for the list item.
    */
-  constructor(host: KittenScientists, label: string, options?: Partial<TOptions>) {
+  constructor(host: KittenScientists, label: string, options?: LabelListItemOptions) {
     super(host, options);
 
     this.head = new Container(host);

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -8,7 +8,7 @@ export type ListItemOptions = UiComponentOptions & {
    */
   readonly delimiter?: boolean;
   readonly classes?: Array<string>;
-};
+} & ThisType<ListItem>;
 
 export class ListItem extends UiComponent {
   declare readonly _options: ListItemOptions;

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import stylesDelimiter from "./Delimiter.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
@@ -12,7 +11,7 @@ export type ListItemOptions = ThisType<ListItem> &
   };
 
 export class ListItem extends UiComponent {
-  declare readonly _options: ListItemOptions;
+  declare readonly options: ListItemOptions;
   readonly element: JQuery;
 
   /**
@@ -21,8 +20,8 @@ export class ListItem extends UiComponent {
    * @param host The userscript instance.
    * @param options Options for the list item.
    */
-  constructor(host: KittenScientists, options?: ListItemOptions) {
-    super(host, { children: (options as UiComponentOptions)?.children });
+  constructor(parent: UiComponent, options?: ListItemOptions) {
+    super(parent, { children: (options as UiComponentOptions)?.children });
 
     this.element = $("<li/>");
 

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -38,5 +38,5 @@ export class ListItem extends UiComponent {
     return `[${ListItem.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -21,7 +21,7 @@ export class ListItem extends UiComponent {
    * @param options Options for the list item.
    */
   constructor(parent: UiComponent, options?: ListItemOptions) {
-    super(parent, { children: (options as UiComponentOptions)?.children });
+    super(parent, { ...options });
 
     this.element = $("<li/>");
 
@@ -32,7 +32,11 @@ export class ListItem extends UiComponent {
     if (options?.delimiter === true) {
       this.element.addClass(stylesDelimiter.delimiter);
     }
-
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${ListItem.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -1,19 +1,17 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import stylesDelimiter from "./Delimiter.module.css";
-import { UiComponent, type UiComponentInterface, type UiComponentOptions } from "./UiComponent.js";
+import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type ListItemOptions<TChild extends UiComponentInterface = UiComponentInterface> =
-  UiComponentOptions<TChild> & {
-    /**
-     * Should there be additional padding below this element?
-     */
-    readonly delimiter: boolean;
-    readonly classes: Array<string>;
-  };
+export type ListItemOptions = UiComponentOptions & {
+  /**
+   * Should there be additional padding below this element?
+   */
+  readonly delimiter?: boolean;
+  readonly classes?: Array<string>;
+};
 
-export class ListItem<
-  TOptions extends ListItemOptions<UiComponent> = ListItemOptions<UiComponent>,
-> extends UiComponent<TOptions> {
+export class ListItem extends UiComponent {
+  declare readonly _options: ListItemOptions;
   readonly element: JQuery;
 
   /**
@@ -22,8 +20,8 @@ export class ListItem<
    * @param host The userscript instance.
    * @param options Options for the list item.
    */
-  constructor(host: KittenScientists, options?: Partial<TOptions>) {
-    super(host, options);
+  constructor(host: KittenScientists, options?: ListItemOptions) {
+    super(host, { children: (options as UiComponentOptions)?.children });
 
     this.element = $("<li/>");
 

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -8,6 +8,7 @@ export type ListItemOptions<TChild extends UiComponentInterface = UiComponentInt
      * Should there be additional padding below this element?
      */
     readonly delimiter: boolean;
+    readonly classes: Array<string>;
   };
 
 export class ListItem<

--- a/source/ui/components/ListItem.ts
+++ b/source/ui/components/ListItem.ts
@@ -2,13 +2,14 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import stylesDelimiter from "./Delimiter.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type ListItemOptions = UiComponentOptions & {
-  /**
-   * Should there be additional padding below this element?
-   */
-  readonly delimiter?: boolean;
-  readonly classes?: Array<string>;
-} & ThisType<ListItem>;
+export type ListItemOptions = ThisType<ListItem> &
+  UiComponentOptions & {
+    /**
+     * Should there be additional padding below this element?
+     */
+    readonly delimiter?: boolean;
+    readonly classes?: Array<string>;
+  };
 
 export class ListItem extends UiComponent {
   declare readonly _options: ListItemOptions;

--- a/source/ui/components/OptionsListItem.ts
+++ b/source/ui/components/OptionsListItem.ts
@@ -56,7 +56,7 @@ export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> e
     return `[${OptionsListItem.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     for (const option of this._items) {
       if (option.option.value === this.setting.selected) {
         option.input.prop("checked", true);

--- a/source/ui/components/OptionsListItem.ts
+++ b/source/ui/components/OptionsListItem.ts
@@ -7,7 +7,7 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 export type OptionsListItemOptions = UiComponentOptions & {
   readonly onCheck?: (isBatchProcess?: boolean) => void;
   readonly readOnly?: boolean;
-};
+} & ThisType<OptionsListItem>;
 
 export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
   declare readonly _options: OptionsListItemOptions;

--- a/source/ui/components/OptionsListItem.ts
+++ b/source/ui/components/OptionsListItem.ts
@@ -52,9 +52,11 @@ export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> e
     this.setting = setting;
   }
 
-  refreshUi() {
-    super.refreshUi();
+  toString(): string {
+    return `[${OptionsListItem.name}#${this.componentId}]`;
+  }
 
+  refreshUi() {
     for (const option of this._items) {
       if (option.option.value === this.setting.selected) {
         option.input.prop("checked", true);

--- a/source/ui/components/OptionsListItem.ts
+++ b/source/ui/components/OptionsListItem.ts
@@ -4,10 +4,11 @@ import { Fieldset } from "./Fieldset.js";
 import { RadioItem } from "./RadioItem.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type OptionsListItemOptions = UiComponentOptions & {
-  readonly onCheck?: (isBatchProcess?: boolean) => void;
-  readonly readOnly?: boolean;
-} & ThisType<OptionsListItem>;
+export type OptionsListItemOptions = ThisType<OptionsListItem> &
+  UiComponentOptions & {
+    readonly onCheck?: (isBatchProcess?: boolean) => void;
+    readonly readOnly?: boolean;
+  };
 
 export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
   declare readonly _options: OptionsListItemOptions;

--- a/source/ui/components/OptionsListItem.ts
+++ b/source/ui/components/OptionsListItem.ts
@@ -5,11 +5,12 @@ import { RadioItem } from "./RadioItem.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type OptionsListItemOptions = UiComponentOptions & {
-  readonly onCheck: (isBatchProcess?: boolean) => void;
-  readonly readOnly: boolean;
+  readonly onCheck?: (isBatchProcess?: boolean) => void;
+  readonly readOnly?: boolean;
 };
 
 export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
+  declare readonly _options: OptionsListItemOptions;
   readonly fieldset: Fieldset;
   readonly setting: TSetting;
   readonly element: JQuery;
@@ -28,9 +29,9 @@ export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> e
     host: KittenScientists,
     label: string,
     setting: TSetting,
-    options?: Partial<Omit<OptionsListItemOptions, "children">>,
+    options?: OptionsListItemOptions,
   ) {
-    super(host, options);
+    super(host, { ...options });
 
     this.element = $("<li/>");
 

--- a/source/ui/components/OptionsListItem.ts
+++ b/source/ui/components/OptionsListItem.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingOptions } from "../../settings/Settings.js";
 import { Fieldset } from "./Fieldset.js";
 import { RadioItem } from "./RadioItem.js";
@@ -11,7 +10,7 @@ export type OptionsListItemOptions = ThisType<OptionsListItem> &
   };
 
 export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
-  declare readonly _options: OptionsListItemOptions;
+  declare readonly options: OptionsListItemOptions;
   readonly fieldset: Fieldset;
   readonly setting: TSetting;
   readonly element: JQuery;
@@ -27,22 +26,22 @@ export class OptionsListItem<TSetting extends SettingOptions = SettingOptions> e
    * @param options Options for the list item.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     label: string,
     setting: TSetting,
     options?: OptionsListItemOptions,
   ) {
-    super(host, { ...options });
+    super(parent, { ...options });
 
     this.element = $("<li/>");
 
-    this.fieldset = new Fieldset(host, label);
+    this.fieldset = new Fieldset(parent, label);
     this.addChild(this.fieldset);
 
     this._items = new Array<RadioItem>();
     for (const option of setting.options) {
       this._items.push(
-        new RadioItem(host, setting, option, label, {
+        new RadioItem(parent, setting, option, label, {
           onCheck: options?.onCheck,
           readOnly: options?.readOnly,
         }),

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -1,7 +1,11 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export class Paragraph extends UiComponent {
+export type ParagraphOptions = UiComponentOptions & {
+  readonly classes: Array<string>;
+};
+
+export class Paragraph<TOptions extends ParagraphOptions = ParagraphOptions> extends UiComponent {
   readonly element: JQuery<HTMLParagraphElement>;
 
   /**
@@ -11,8 +15,8 @@ export class Paragraph extends UiComponent {
    * @param text - The text inside the paragraph.
    * @param options - Options for the UI element.
    */
-  constructor(host: KittenScientists, text: string, options?: Partial<UiComponentOptions>) {
-    super(host, { ...options, children: [], classes: [] });
+  constructor(host: KittenScientists, text: string, options?: Partial<TOptions>) {
+    super(host, { ...options, children: [] });
 
     this.element = $<HTMLParagraphElement>("<p/>").text(text);
 

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -3,7 +3,7 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type ParagraphOptions = UiComponentOptions & {
   readonly classes?: Array<string>;
-};
+} & ThisType<Paragraph>;
 
 export class Paragraph extends UiComponent {
   declare readonly _options: ParagraphOptions;

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -17,14 +17,18 @@ export class Paragraph extends UiComponent {
    * @param options - Options for the UI element.
    */
   constructor(parent: UiComponent, text: string, options?: ParagraphOptions) {
-    super(parent, { ...options, children: [] });
+    super(parent, { ...options });
 
     this.element = $<HTMLParagraphElement>("<p/>").text(text);
 
     for (const className of options?.classes ?? []) {
       this.element.addClass(className);
     }
-
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${Paragraph.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -30,5 +30,5 @@ export class Paragraph extends UiComponent {
     return `[${Paragraph.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -2,10 +2,11 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type ParagraphOptions = UiComponentOptions & {
-  readonly classes: Array<string>;
+  readonly classes?: Array<string>;
 };
 
-export class Paragraph<TOptions extends ParagraphOptions = ParagraphOptions> extends UiComponent {
+export class Paragraph extends UiComponent {
+  declare readonly _options: ParagraphOptions;
   readonly element: JQuery<HTMLParagraphElement>;
 
   /**
@@ -15,7 +16,7 @@ export class Paragraph<TOptions extends ParagraphOptions = ParagraphOptions> ext
    * @param text - The text inside the paragraph.
    * @param options - Options for the UI element.
    */
-  constructor(host: KittenScientists, text: string, options?: Partial<TOptions>) {
+  constructor(host: KittenScientists, text: string, options?: ParagraphOptions) {
     super(host, { ...options, children: [] });
 
     this.element = $<HTMLParagraphElement>("<p/>").text(text);

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -1,9 +1,10 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type ParagraphOptions = UiComponentOptions & {
-  readonly classes?: Array<string>;
-} & ThisType<Paragraph>;
+export type ParagraphOptions = ThisType<Paragraph> &
+  UiComponentOptions & {
+    readonly classes?: Array<string>;
+  };
 
 export class Paragraph extends UiComponent {
   declare readonly _options: ParagraphOptions;

--- a/source/ui/components/Paragraph.ts
+++ b/source/ui/components/Paragraph.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type ParagraphOptions = ThisType<Paragraph> &
@@ -7,7 +6,7 @@ export type ParagraphOptions = ThisType<Paragraph> &
   };
 
 export class Paragraph extends UiComponent {
-  declare readonly _options: ParagraphOptions;
+  declare readonly options: ParagraphOptions;
   readonly element: JQuery<HTMLParagraphElement>;
 
   /**
@@ -17,8 +16,8 @@ export class Paragraph extends UiComponent {
    * @param text - The text inside the paragraph.
    * @param options - Options for the UI element.
    */
-  constructor(host: KittenScientists, text: string, options?: ParagraphOptions) {
-    super(host, { ...options, children: [] });
+  constructor(parent: UiComponent, text: string, options?: ParagraphOptions) {
+    super(parent, { ...options, children: [] });
 
     this.element = $<HTMLParagraphElement>("<p/>").text(text);
 

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -10,26 +10,27 @@ export type RadioItemOptions = UiComponentOptions & {
   /**
    * Will be invoked when the user selects this radio item.
    */
-  onCheck: (isBatchProcess?: boolean) => void;
+  onCheck?: (isBatchProcess?: boolean) => void;
 
   /**
    * Should there be additional padding below this element?
    */
-  delimiter: boolean;
+  delimiter?: boolean;
 
   /**
    * Should an indicator be rendered in front of the element,
    * to indicate that this is an upgrade of a prior setting?
    */
-  upgradeIndicator: boolean;
+  upgradeIndicator?: boolean;
 
   /**
    * Should the user be prevented from changing the value of the input?
    */
-  readOnly: boolean;
+  readOnly?: boolean;
 };
 
 export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
+  declare readonly _options: RadioItemOptions;
   readonly setting: TSetting;
   readonly option: TSetting["options"][0];
   readonly element: JQuery;
@@ -52,9 +53,9 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
     setting: TSetting,
     option: TSetting["options"][0],
     groupKey: string,
-    options?: Partial<RadioItemOptions>,
+    options?: RadioItemOptions,
   ) {
-    super(host, options);
+    super(host, { ...options });
 
     const element = $("<div/>");
     element.addClass(stylesSettingListItem.setting);

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -27,7 +27,7 @@ export type RadioItemOptions = UiComponentOptions & {
    * Should the user be prevented from changing the value of the input?
    */
   readOnly?: boolean;
-};
+} & ThisType<RadioItem>;
 
 export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
   declare readonly _options: RadioItemOptions;

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingOptions } from "../../settings/Settings.js";
 import stylesDelimiter from "./Delimiter.module.css";
 import stylesLabel from "./LabelListItem.module.css";
@@ -31,7 +30,7 @@ export type RadioItemOptions = ThisType<RadioItem> &
   };
 
 export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
-  declare readonly _options: RadioItemOptions;
+  declare readonly options: RadioItemOptions;
   readonly setting: TSetting;
   readonly option: TSetting["options"][0];
   readonly element: JQuery;
@@ -50,13 +49,13 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
    * @param options Options for this radio item.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: TSetting,
     option: TSetting["options"][0],
     groupKey: string,
     options?: RadioItemOptions,
   ) {
-    super(host, { ...options });
+    super(parent, { ...options });
 
     const element = $("<div/>");
     element.addClass(stylesSettingListItem.setting);

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -34,6 +34,7 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
   readonly setting: TSetting;
   readonly option: TSetting["options"][0];
   readonly element: JQuery;
+  readonly elementLabel: JQuery<HTMLLabelElement>;
   readonly input: JQuery;
 
   readOnly: boolean;
@@ -64,7 +65,7 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
       element.addClass(stylesDelimiter.delimiter);
     }
 
-    const elementLabel = $("<label/>", {
+    this.elementLabel = $<HTMLLabelElement>("<label/>", {
       text: `${options?.upgradeIndicator ? "⮤ " : ""}${option.label}`,
     }).addClass(stylesLabel.label);
 
@@ -82,19 +83,20 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
       }
     });
 
-    elementLabel.prepend(input);
-    element.append(elementLabel);
+    this.elementLabel.prepend(input);
+    element.append(this.elementLabel);
 
     this.input = input;
     this.element = element;
-    this.addChildren(options?.children);
     this.setting = setting;
     this.option = option;
   }
 
-  refreshUi() {
-    super.refreshUi();
+  toString(): string {
+    return `[${RadioItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+  }
 
+  refreshUi() {
     this.input.prop("disabled", this.readOnly);
   }
 }

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -93,7 +93,7 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
   }
 
   toString(): string {
-    return `[${RadioItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${RadioItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 
   refreshUi(): void {

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -6,28 +6,29 @@ import stylesLabel from "./LabelListItem.module.css";
 import stylesSettingListItem from "./SettingListItem.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type RadioItemOptions = UiComponentOptions & {
-  /**
-   * Will be invoked when the user selects this radio item.
-   */
-  onCheck?: (isBatchProcess?: boolean) => void;
+export type RadioItemOptions = ThisType<RadioItem> &
+  UiComponentOptions & {
+    /**
+     * Will be invoked when the user selects this radio item.
+     */
+    onCheck?: (isBatchProcess?: boolean) => void;
 
-  /**
-   * Should there be additional padding below this element?
-   */
-  delimiter?: boolean;
+    /**
+     * Should there be additional padding below this element?
+     */
+    delimiter?: boolean;
 
-  /**
-   * Should an indicator be rendered in front of the element,
-   * to indicate that this is an upgrade of a prior setting?
-   */
-  upgradeIndicator?: boolean;
+    /**
+     * Should an indicator be rendered in front of the element,
+     * to indicate that this is an upgrade of a prior setting?
+     */
+    upgradeIndicator?: boolean;
 
-  /**
-   * Should the user be prevented from changing the value of the input?
-   */
-  readOnly?: boolean;
-} & ThisType<RadioItem>;
+    /**
+     * Should the user be prevented from changing the value of the input?
+     */
+    readOnly?: boolean;
+  };
 
 export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends UiComponent {
   declare readonly _options: RadioItemOptions;

--- a/source/ui/components/RadioItem.ts
+++ b/source/ui/components/RadioItem.ts
@@ -96,7 +96,7 @@ export class RadioItem<TSetting extends SettingOptions = SettingOptions> extends
     return `[${RadioItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     this.input.prop("disabled", this.readOnly);
   }
 }

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -79,4 +79,8 @@ export class SeasonsList extends SettingsList {
 
     this.addChildren([this.spring, this.summer, this.autumn, this.winter]);
   }
+
+  toString(): string {
+    return `[${SeasonsList.name}#${this.componentId}]`;
+  }
 }

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -6,14 +6,14 @@ import { SettingsList, type SettingsListOptions } from "./SettingsList.js";
 
 export type SettingWithSeasons = Record<Season, Setting>;
 
-export type SeasonsListOptions = SettingsListOptions<SettingListItem> & {
+export type SeasonsListOptions = SettingsListOptions & {
   /**
    * Called when a season is checked.
    *
    * @param label The label on the season element.
    * @param setting The setting associated with the season.
    */
-  readonly onCheck: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
+  readonly onCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
 
   /**
    * Called when a season is unchecked.
@@ -21,7 +21,7 @@ export type SeasonsListOptions = SettingsListOptions<SettingListItem> & {
    * @param label The label on the season element.
    * @param setting The setting associated with the season.
    */
-  readonly onUnCheck: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
+  readonly onUnCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
 };
 
 /**
@@ -42,11 +42,7 @@ export class SeasonsList extends SettingsList {
    * @param setting The settings that correlate to this list.
    * @param options Options for this list
    */
-  constructor(
-    host: KittenScientists,
-    setting: SettingWithSeasons,
-    options?: Partial<SeasonsListOptions>,
-  ) {
+  constructor(host: KittenScientists, setting: SettingWithSeasons, options?: SeasonsListOptions) {
     super(host, options);
     this.setting = setting;
 
@@ -65,41 +61,32 @@ export class SeasonsList extends SettingsList {
       this.refreshUi();
     });
 
-    this.spring = this._makeSeason(
+    const makeSeason = (label: string, setting: Setting) => {
+      return new SettingListItem(host, setting, label, {
+        onCheck: (isBatchProcess?: boolean) =>
+          options?.onCheckSeason?.(label, setting, isBatchProcess),
+        onUnCheck: (isBatchProcess?: boolean) =>
+          options?.onUnCheckSeason?.(label, setting, isBatchProcess),
+      });
+    };
+
+    this.spring = makeSeason(
       this._host.engine.i18n("$calendar.season.spring"),
       this.setting.spring,
-      options,
     );
-    this.summer = this._makeSeason(
+    this.summer = makeSeason(
       this._host.engine.i18n("$calendar.season.summer"),
       this.setting.summer,
-      options,
     );
-    this.autumn = this._makeSeason(
+    this.autumn = makeSeason(
       this._host.engine.i18n("$calendar.season.autumn"),
       this.setting.autumn,
-      options,
     );
-    this.winter = this._makeSeason(
+    this.winter = makeSeason(
       this._host.engine.i18n("$calendar.season.winter"),
       this.setting.winter,
-      options,
     );
 
     this.addChildren([this.spring, this.summer, this.autumn, this.winter]);
-  }
-
-  private _makeSeason(
-    label: string,
-    setting: Setting,
-    handler?: Partial<{
-      onCheck: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-      onUnCheck: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-    }>,
-  ) {
-    return new SettingListItem(this._host, setting, label, {
-      onCheck: (isBatchProcess?: boolean) => handler?.onCheck?.(label, setting, isBatchProcess),
-      onUnCheck: (isBatchProcess?: boolean) => handler?.onUnCheck?.(label, setting, isBatchProcess),
-    });
   }
 }

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -22,7 +22,7 @@ export type SeasonsListOptions = SettingsListOptions & {
    * @param setting The setting associated with the season.
    */
   readonly onUnCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-};
+} & ThisType<SeasonsList>;
 
 /**
  * A list of 4 settings correlating to the 4 seasons.

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -28,6 +28,7 @@ export type SeasonsListOptions = SettingsListOptions & {
  * A list of 4 settings correlating to the 4 seasons.
  */
 export class SeasonsList extends SettingsList {
+  declare readonly _options: SeasonsListOptions;
   readonly setting: SettingWithSeasons;
 
   readonly spring: SettingListItem;

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -6,23 +6,24 @@ import { SettingsList, type SettingsListOptions } from "./SettingsList.js";
 
 export type SettingWithSeasons = Record<Season, Setting>;
 
-export type SeasonsListOptions = SettingsListOptions & {
-  /**
-   * Called when a season is checked.
-   *
-   * @param label The label on the season element.
-   * @param setting The setting associated with the season.
-   */
-  readonly onCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
+export type SeasonsListOptions = ThisType<SeasonsList> &
+  SettingsListOptions & {
+    /**
+     * Called when a season is checked.
+     *
+     * @param label The label on the season element.
+     * @param setting The setting associated with the season.
+     */
+    readonly onCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
 
-  /**
-   * Called when a season is unchecked.
-   *
-   * @param label The label on the season element.
-   * @param setting The setting associated with the season.
-   */
-  readonly onUnCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
-} & ThisType<SeasonsList>;
+    /**
+     * Called when a season is unchecked.
+     *
+     * @param label The label on the season element.
+     * @param setting The setting associated with the season.
+     */
+    readonly onUnCheckSeason?: (label: string, setting: Setting, isBatchProcess?: boolean) => void;
+  };
 
 /**
  * A list of 4 settings correlating to the 4 seasons.

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -1,8 +1,8 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
 import type { Season } from "../../types/index.js";
 import { SettingListItem } from "./SettingListItem.js";
 import { SettingsList, type SettingsListOptions } from "./SettingsList.js";
+import type { UiComponent } from "./UiComponent.js";
 
 export type SettingWithSeasons = Record<Season, Setting>;
 
@@ -29,7 +29,7 @@ export type SeasonsListOptions = ThisType<SeasonsList> &
  * A list of 4 settings correlating to the 4 seasons.
  */
 export class SeasonsList extends SettingsList {
-  declare readonly _options: SeasonsListOptions;
+  declare readonly options: SeasonsListOptions;
   readonly setting: SettingWithSeasons;
 
   readonly spring: SettingListItem;
@@ -44,8 +44,8 @@ export class SeasonsList extends SettingsList {
    * @param setting The settings that correlate to this list.
    * @param options Options for this list
    */
-  constructor(host: KittenScientists, setting: SettingWithSeasons, options?: SeasonsListOptions) {
-    super(host, options);
+  constructor(parent: UiComponent, setting: SettingWithSeasons, options?: SeasonsListOptions) {
+    super(parent, options);
     this.setting = setting;
 
     this.addEventListener("enableAll", () => {
@@ -64,7 +64,7 @@ export class SeasonsList extends SettingsList {
     });
 
     const makeSeason = (label: string, setting: Setting) => {
-      return new SettingListItem(host, setting, label, {
+      return new SettingListItem(parent, setting, label, {
         onCheck: (isBatchProcess?: boolean) =>
           options?.onCheckSeason?.(label, setting, isBatchProcess),
         onUnCheck: (isBatchProcess?: boolean) =>
@@ -72,22 +72,10 @@ export class SeasonsList extends SettingsList {
       });
     };
 
-    this.spring = makeSeason(
-      this._host.engine.i18n("$calendar.season.spring"),
-      this.setting.spring,
-    );
-    this.summer = makeSeason(
-      this._host.engine.i18n("$calendar.season.summer"),
-      this.setting.summer,
-    );
-    this.autumn = makeSeason(
-      this._host.engine.i18n("$calendar.season.autumn"),
-      this.setting.autumn,
-    );
-    this.winter = makeSeason(
-      this._host.engine.i18n("$calendar.season.winter"),
-      this.setting.winter,
-    );
+    this.spring = makeSeason(this.host.engine.i18n("$calendar.season.spring"), this.setting.spring);
+    this.summer = makeSeason(this.host.engine.i18n("$calendar.season.summer"), this.setting.summer);
+    this.autumn = makeSeason(this.host.engine.i18n("$calendar.season.autumn"), this.setting.autumn);
+    this.winter = makeSeason(this.host.engine.i18n("$calendar.season.winter"), this.setting.winter);
 
     this.addChildren([this.spring, this.summer, this.autumn, this.winter]);
   }

--- a/source/ui/components/SeasonsList.ts
+++ b/source/ui/components/SeasonsList.ts
@@ -53,22 +53,24 @@ export class SeasonsList extends SettingsList {
       this.spring.check(true);
       this.summer.check(true);
       this.winter.check(true);
-      this.refreshUi();
     });
     this.addEventListener("disableAll", () => {
       this.autumn.uncheck(true);
       this.spring.uncheck(true);
       this.summer.uncheck(true);
       this.winter.uncheck(true);
-      this.refreshUi();
     });
 
     const makeSeason = (label: string, setting: Setting) => {
       return new SettingListItem(parent, setting, label, {
-        onCheck: (isBatchProcess?: boolean) =>
-          options?.onCheckSeason?.(label, setting, isBatchProcess),
-        onUnCheck: (isBatchProcess?: boolean) =>
-          options?.onUnCheckSeason?.(label, setting, isBatchProcess),
+        onCheck: (isBatchProcess?: boolean) => {
+          options?.onCheckSeason?.(label, setting, isBatchProcess);
+          this.requestRefresh();
+        },
+        onUnCheck: (isBatchProcess?: boolean) => {
+          options?.onUnCheckSeason?.(label, setting, isBatchProcess);
+          this.requestRefresh();
+        },
       });
     };
 

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -1,8 +1,8 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingLimited } from "../../settings/Settings.js";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 
 export type SettingLimitedListItemOptions = ThisType<SettingLimitedListItem> &
@@ -19,7 +19,7 @@ export type SettingLimitedListItemOptions = ThisType<SettingLimitedListItem> &
   };
 
 export class SettingLimitedListItem extends SettingListItem {
-  declare readonly _options: SettingLimitedListItemOptions;
+  declare readonly options: SettingLimitedListItemOptions;
   readonly limitedButton: LimitedButton;
 
   /**
@@ -32,18 +32,18 @@ export class SettingLimitedListItem extends SettingListItem {
    * @param options Options for the list item.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingLimited,
     label: string,
     options?: SettingLimitedListItemOptions,
   ) {
-    super(host, setting, label, options);
+    super(parent, setting, label, options);
 
-    this.limitedButton = new LimitedButton(host, setting, {
+    this.limitedButton = new LimitedButton(parent, setting, {
       ...options,
     });
     this.head.addChildren([
-      new Container(host, { classes: [stylesLabelListItem.fillSpace] }),
+      new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.limitedButton,
     ]);
   }

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -5,17 +5,18 @@ import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 
-export type SettingLimitedListItemOptions = SettingListItemOptions & {
-  /**
-   * Is called when the "Limited" checkbox is checked.
-   */
-  readonly onLimitedCheck?: () => void;
+export type SettingLimitedListItemOptions = ThisType<SettingLimitedListItem> &
+  SettingListItemOptions & {
+    /**
+     * Is called when the "Limited" checkbox is checked.
+     */
+    readonly onLimitedCheck?: () => void;
 
-  /**
-   * Is called when the "Limited" checkbox is unchecked.
-   */
-  readonly onLimitedUnCheck?: () => void;
-} & ThisType<SettingLimitedListItem>;
+    /**
+     * Is called when the "Limited" checkbox is unchecked.
+     */
+    readonly onLimitedUnCheck?: () => void;
+  };
 
 export class SettingLimitedListItem extends SettingListItem {
   declare readonly _options: SettingLimitedListItemOptions;

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -3,24 +3,22 @@ import type { SettingLimited } from "../../settings/Settings.js";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
-import type { UiComponent } from "./UiComponent.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 
-export type SettingLimitedListItemOptions = SettingListItemOptions<UiComponent> & {
+export type SettingLimitedListItemOptions = SettingListItemOptions & {
   /**
    * Is called when the "Limited" checkbox is checked.
    */
-  readonly onLimitedCheck: () => void;
+  readonly onLimitedCheck?: () => void;
 
   /**
    * Is called when the "Limited" checkbox is unchecked.
    */
-  readonly onLimitedUnCheck: () => void;
+  readonly onLimitedUnCheck?: () => void;
 };
 
-export class SettingLimitedListItem<
-  TOptions extends SettingLimitedListItemOptions = SettingLimitedListItemOptions,
-> extends SettingListItem {
+export class SettingLimitedListItem extends SettingListItem {
+  declare readonly _options: SettingLimitedListItemOptions;
   readonly limitedButton: LimitedButton;
 
   /**
@@ -36,7 +34,7 @@ export class SettingLimitedListItem<
     host: KittenScientists,
     setting: SettingLimited,
     label: string,
-    options?: Partial<TOptions>,
+    options?: SettingLimitedListItemOptions,
   ) {
     super(host, setting, label, options);
 

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -15,7 +15,7 @@ export type SettingLimitedListItemOptions = SettingListItemOptions & {
    * Is called when the "Limited" checkbox is unchecked.
    */
   readonly onLimitedUnCheck?: () => void;
-};
+} & ThisType<SettingLimitedListItem>;
 
 export class SettingLimitedListItem extends SettingListItem {
   declare readonly _options: SettingLimitedListItemOptions;

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -42,15 +42,13 @@ export class SettingLimitedListItem extends SettingListItem {
     this.limitedButton = new LimitedButton(parent, setting, {
       ...options,
     });
-    this.head.addChildren([
+    this.addChildrenHead([
       new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.limitedButton,
     ]);
   }
 
-  refreshUi() {
-    super.refreshUi();
-
-    this.limitedButton.refreshUi();
+  toString(): string {
+    return `[${SettingLimitedListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 }

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -6,7 +6,7 @@ import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.
 import type { UiComponent } from "./UiComponent.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 
-export type SettingListItemOptionsLimited = {
+export type SettingLimitedListItemOptions = SettingListItemOptions<UiComponent> & {
   /**
    * Is called when the "Limited" checkbox is checked.
    */
@@ -19,9 +19,7 @@ export type SettingListItemOptionsLimited = {
 };
 
 export class SettingLimitedListItem<
-  TOptions extends SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsLimited = SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsLimited,
+  TOptions extends SettingLimitedListItemOptions = SettingLimitedListItemOptions,
 > extends SettingListItem {
   readonly limitedButton: LimitedButton;
 

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -35,7 +35,7 @@ export class SettingLimitedListItem extends SettingListItem {
     parent: UiComponent,
     setting: SettingLimited,
     label: string,
-    options?: SettingLimitedListItemOptions,
+    options: SettingLimitedListItemOptions,
   ) {
     super(parent, setting, label, options);
 

--- a/source/ui/components/SettingLimitedListItem.ts
+++ b/source/ui/components/SettingLimitedListItem.ts
@@ -49,6 +49,6 @@ export class SettingLimitedListItem extends SettingListItem {
   }
 
   toString(): string {
-    return `[${SettingLimitedListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${SettingLimitedListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 }

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -29,17 +29,15 @@ export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
 
     this.triggerButton = new TriggerButton(host, setting, locale, {
       border: false,
-      onClick: (event?: MouseEvent) => this._onClickTrigger(event),
+      onClick: async (event?: MouseEvent) => {
+        await this._options.onSetTrigger.call(this);
+        this.refreshUi();
+      },
       onRefreshTitle: options?.onRefreshTrigger
         ? () => options.onRefreshTrigger?.call(this)
         : undefined,
     });
     this.head.addChild(this.triggerButton);
-  }
-
-  private _onClickTrigger(event?: MouseEvent): void {
-    this._options.onSetTrigger.call(this);
-    this.refreshUi();
   }
 
   refreshUi() {

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -29,7 +29,10 @@ export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
 
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
-      onClick: () => options.onSetTrigger.call(this),
+      onClick: () => {
+        options.onSetTrigger.call(this);
+        this.requestRefresh();
+      },
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
     this.addChildHead(this.triggerButton);

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../../Engine.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingLimitedTrigger, SettingOptions } from "../../settings/Settings.js";
 import {
   SettingLimitedListItem,
@@ -7,6 +6,7 @@ import {
 } from "./SettingLimitedListItem.js";
 import type { SettingListItemOptions } from "./SettingListItem.js";
 import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
 export type SettingLimitedTriggerListItemOptions = SettingListItemOptions &
@@ -15,22 +15,22 @@ export type SettingLimitedTriggerListItemOptions = SettingListItemOptions &
   ThisType<SettingLimitedTriggerListItem>;
 
 export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
-  declare readonly _options: SettingLimitedTriggerListItemOptions;
+  declare readonly options: SettingLimitedTriggerListItemOptions;
   readonly triggerButton: TriggerButton;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingLimitedTrigger,
     locale: SettingOptions<SupportedLocale>,
     label: string,
     options?: SettingLimitedTriggerListItemOptions,
   ) {
-    super(host, setting, label, options);
+    super(parent, setting, label, options);
 
-    this.triggerButton = new TriggerButton(host, setting, locale, {
+    this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       onClick: async (event?: MouseEvent) => {
-        await this._options.onSetTrigger.call(this);
+        await this.options.onSetTrigger.call(this);
         this.refreshUi();
       },
       onRefreshTitle: options?.onRefreshTrigger

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -31,14 +31,14 @@ export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
       border: false,
       onClick: (event?: MouseEvent) => this._onClickTrigger(event),
       onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.(this)
+        ? () => options.onRefreshTrigger?.call(this)
         : undefined,
     });
     this.head.addChild(this.triggerButton);
   }
 
   private _onClickTrigger(event?: MouseEvent): void {
-    this._options.onSetTrigger(this);
+    this._options.onSetTrigger.call(this);
     this.refreshUi();
   }
 

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -29,20 +29,13 @@ export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
 
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
-      onClick: async (event?: MouseEvent) => {
-        await this.options.onSetTrigger.call(this);
-        this.refreshUi();
-      },
-      onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.call(this)
-        : undefined,
+      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
+      onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
-    this.head.addChild(this.triggerButton);
+    this.addChildHead(this.triggerButton);
   }
 
-  refreshUi() {
-    super.refreshUi();
-
-    this.triggerButton.refreshUi();
+  toString(): string {
+    return `[${SettingLimitedTriggerListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 }

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -23,13 +23,13 @@ export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
     setting: SettingLimitedTrigger,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: SettingLimitedTriggerListItemOptions,
+    options: SettingLimitedTriggerListItemOptions,
   ) {
     super(parent, setting, label, options);
 
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
+      onClick: () => options.onSetTrigger.call(this),
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
     this.addChildHead(this.triggerButton);

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -11,7 +11,8 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 
 export type SettingLimitedTriggerListItemOptions = SettingListItemOptions &
   SettingLimitedListItemOptions &
-  SettingTriggerListItemOptions;
+  SettingTriggerListItemOptions &
+  ThisType<SettingLimitedTriggerListItem>;
 
 export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
   declare readonly _options: SettingLimitedTriggerListItemOptions;

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -7,16 +7,14 @@ import {
 } from "./SettingLimitedListItem.js";
 import type { SettingListItemOptions } from "./SettingListItem.js";
 import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
-import type { UiComponent } from "./UiComponent.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type SettingLimitedTriggerListItemOptions = SettingListItemOptions<UiComponent> &
+export type SettingLimitedTriggerListItemOptions = SettingListItemOptions &
   SettingLimitedListItemOptions &
   SettingTriggerListItemOptions;
 
-export class SettingLimitedTriggerListItem<
-  TOptions extends SettingLimitedTriggerListItemOptions = SettingLimitedTriggerListItemOptions,
-> extends SettingLimitedListItem {
+export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
+  declare readonly _options: SettingLimitedTriggerListItemOptions;
   readonly triggerButton: TriggerButton;
 
   constructor(
@@ -24,18 +22,23 @@ export class SettingLimitedTriggerListItem<
     setting: SettingLimitedTrigger,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: Partial<TOptions>,
+    options?: SettingLimitedTriggerListItemOptions,
   ) {
     super(host, setting, label, options);
 
     this.triggerButton = new TriggerButton(host, setting, locale, {
       border: false,
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.(this) : undefined,
+      onClick: (event?: MouseEvent) => this._onClickTrigger(event),
       onRefreshTitle: options?.onRefreshTrigger
         ? () => options.onRefreshTrigger?.(this)
         : undefined,
     });
     this.head.addChild(this.triggerButton);
+  }
+
+  private _onClickTrigger(event?: MouseEvent): void {
+    this._options.onSetTrigger(this);
+    this.refreshUi();
   }
 
   refreshUi() {

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -3,19 +3,19 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingLimitedTrigger, SettingOptions } from "../../settings/Settings.js";
 import {
   SettingLimitedListItem,
-  type SettingListItemOptionsLimited,
+  type SettingLimitedListItemOptions,
 } from "./SettingLimitedListItem.js";
 import type { SettingListItemOptions } from "./SettingListItem.js";
-import type { SettingListItemOptionsTrigger } from "./SettingTriggerListItem.js";
+import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
 import type { UiComponent } from "./UiComponent.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
+export type SettingLimitedTriggerListItemOptions = SettingListItemOptions<UiComponent> &
+  SettingLimitedListItemOptions &
+  SettingTriggerListItemOptions;
+
 export class SettingLimitedTriggerListItem<
-  TOptions extends SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsLimited &
-    SettingListItemOptionsTrigger = SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsLimited &
-    SettingListItemOptionsTrigger,
+  TOptions extends SettingLimitedTriggerListItemOptions = SettingLimitedTriggerListItemOptions,
 > extends SettingLimitedListItem {
   readonly triggerButton: TriggerButton;
 

--- a/source/ui/components/SettingLimitedTriggerListItem.ts
+++ b/source/ui/components/SettingLimitedTriggerListItem.ts
@@ -29,16 +29,17 @@ export class SettingLimitedTriggerListItem extends SettingLimitedListItem {
 
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
-      onClick: () => {
-        options.onSetTrigger.call(this);
+      onClick: async () => {
+        await options.onSetTrigger.call(this);
         this.requestRefresh();
       },
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
+      renderLabel: options?.renderLabelTrigger ?? true,
     });
     this.addChildHead(this.triggerButton);
   }
 
   toString(): string {
-    return `[${SettingLimitedTriggerListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${SettingLimitedTriggerListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 }

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -82,13 +82,13 @@ export class SettingListItem<TSetting extends Setting = Setting> extends LabelLi
 
   check(isBatchProcess = false) {
     this.setting.enabled = true;
-    this._options?.onCheck?.(isBatchProcess);
+    this._options?.onCheck?.call(isBatchProcess);
     this.refreshUi();
   }
 
   uncheck(isBatchProcess = false) {
     this.setting.enabled = false;
-    this._options.onUnCheck?.(isBatchProcess);
+    this._options.onUnCheck?.call(isBatchProcess);
     this.refreshUi();
   }
 

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -3,30 +3,26 @@ import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
 import { LabelListItem, type LabelListItemOptions } from "./LabelListItem.js";
 import { default as styles, default as stylesSettingListItem } from "./SettingListItem.module.css";
-import type { UiComponent, UiComponentInterface } from "./UiComponent.js";
 
-export type SettingListItemOptions<TChild extends UiComponentInterface = UiComponentInterface> =
-  LabelListItemOptions<TChild> & {
-    /**
-     * Will be invoked when the user checks the checkbox.
-     */
-    readonly onCheck: (isBatchProcess?: boolean) => void;
+export type SettingListItemOptions = LabelListItemOptions & {
+  /**
+   * Will be invoked when the user checks the checkbox.
+   */
+  readonly onCheck?: (isBatchProcess?: boolean) => void;
 
-    /**
-     * Will be invoked when the user unchecks the checkbox.
-     */
-    readonly onUnCheck: (isBatchProcess?: boolean) => void;
+  /**
+   * Will be invoked when the user unchecks the checkbox.
+   */
+  readonly onUnCheck?: (isBatchProcess?: boolean) => void;
 
-    /**
-     * Should the user be prevented from changing the value of the input?
-     */
-    readonly readOnly: boolean;
-  };
+  /**
+   * Should the user be prevented from changing the value of the input?
+   */
+  readonly readOnly?: boolean;
+};
 
-export class SettingListItem<
-  TSetting extends Setting = Setting,
-  TOptions extends SettingListItemOptions<UiComponent> = SettingListItemOptions<UiComponent>,
-> extends LabelListItem<TOptions> {
+export class SettingListItem<TSetting extends Setting = Setting> extends LabelListItem {
+  declare readonly _options: SettingListItemOptions;
   readonly setting: TSetting;
   readonly checkbox?: JQuery;
 
@@ -47,7 +43,7 @@ export class SettingListItem<
     host: KittenScientists,
     setting: TSetting,
     label: string,
-    options: Partial<TOptions> = {},
+    options?: SettingListItemOptions,
   ) {
     super(host, label, { ...options, children: [] });
 
@@ -59,17 +55,17 @@ export class SettingListItem<
       type: "checkbox",
     }).addClass(styles.checkbox);
 
-    this.readOnly = options.readOnly ?? false;
+    this.readOnly = options?.readOnly ?? false;
     checkbox.prop("disabled", this.readOnly);
 
     checkbox.on("change", () => {
       if (checkbox.is(":checked") && !setting.enabled) {
         setting.enabled = true;
-        options.onCheck?.();
+        options?.onCheck?.();
         this.refreshUi();
       } else if (!checkbox.is(":checked") && setting.enabled) {
         setting.enabled = false;
-        options.onUnCheck?.();
+        options?.onUnCheck?.();
         this.refreshUi();
       }
     });
@@ -80,12 +76,12 @@ export class SettingListItem<
     this.checkbox = checkbox;
     this.setting = setting;
 
-    this.addChildren(options.children);
+    this.addChildren(options?.children);
   }
 
   check(isBatchProcess = false) {
     this.setting.enabled = true;
-    this._options.onCheck?.(isBatchProcess);
+    this._options?.onCheck?.(isBatchProcess);
     this.refreshUi();
   }
 

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -88,7 +88,7 @@ export class SettingListItem<TSetting extends Setting = Setting> extends LabelLi
     this.requestRefresh(true);
   }
 
-  refreshUi() {
+  refreshUi(): void {
     if (this.setting.enabled) {
       this.element.addClass(styles.checked);
     } else {

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -1,8 +1,8 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
 import { LabelListItem, type LabelListItemOptions } from "./LabelListItem.js";
 import { default as styles, default as stylesSettingListItem } from "./SettingListItem.module.css";
+import type { UiComponent } from "./UiComponent.js";
 
 export type SettingListItemOptions = ThisType<SettingListItem> &
   LabelListItemOptions & {
@@ -23,7 +23,7 @@ export type SettingListItemOptions = ThisType<SettingListItem> &
   };
 
 export class SettingListItem<TSetting extends Setting = Setting> extends LabelListItem {
-  declare readonly _options: SettingListItemOptions;
+  declare readonly options: SettingListItemOptions;
   readonly setting: TSetting;
   readonly checkbox?: JQuery;
 
@@ -41,12 +41,12 @@ export class SettingListItem<TSetting extends Setting = Setting> extends LabelLi
    * @param options Options for this list item.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: TSetting,
     label: string,
     options?: SettingListItemOptions,
   ) {
-    super(host, label, { ...options, children: [] });
+    super(parent, label, { ...options, children: [] });
 
     this.element.addClass(styles.setting);
 
@@ -82,13 +82,13 @@ export class SettingListItem<TSetting extends Setting = Setting> extends LabelLi
 
   async check(isBatchProcess = false) {
     this.setting.enabled = true;
-    await this._options?.onCheck?.call(isBatchProcess);
+    await this.options?.onCheck?.call(isBatchProcess);
     this.refreshUi();
   }
 
   async uncheck(isBatchProcess = false) {
     this.setting.enabled = false;
-    await this._options.onUnCheck?.call(isBatchProcess);
+    await this.options.onUnCheck?.call(isBatchProcess);
     this.refreshUi();
   }
 

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -73,7 +73,7 @@ export class SettingListItem<TSetting extends Setting = Setting> extends LabelLi
   }
 
   toString(): string {
-    return `[${SettingListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${SettingListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 
   async check(isBatchProcess = false) {

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -19,7 +19,7 @@ export type SettingListItemOptions = LabelListItemOptions & {
    * Should the user be prevented from changing the value of the input?
    */
   readonly readOnly?: boolean;
-};
+} & ThisType<SettingListItem>;
 
 export class SettingListItem<TSetting extends Setting = Setting> extends LabelListItem {
   declare readonly _options: SettingListItemOptions;

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -4,22 +4,23 @@ import type { Setting } from "../../settings/Settings.js";
 import { LabelListItem, type LabelListItemOptions } from "./LabelListItem.js";
 import { default as styles, default as stylesSettingListItem } from "./SettingListItem.module.css";
 
-export type SettingListItemOptions = LabelListItemOptions & {
-  /**
-   * Will be invoked when the user checks the checkbox.
-   */
-  readonly onCheck?: (isBatchProcess?: boolean) => void;
+export type SettingListItemOptions = ThisType<SettingListItem> &
+  LabelListItemOptions & {
+    /**
+     * Will be invoked when the user checks the checkbox.
+     */
+    readonly onCheck?: (isBatchProcess?: boolean) => void;
 
-  /**
-   * Will be invoked when the user unchecks the checkbox.
-   */
-  readonly onUnCheck?: (isBatchProcess?: boolean) => void;
+    /**
+     * Will be invoked when the user unchecks the checkbox.
+     */
+    readonly onUnCheck?: (isBatchProcess?: boolean) => void;
 
-  /**
-   * Should the user be prevented from changing the value of the input?
-   */
-  readonly readOnly?: boolean;
-} & ThisType<SettingListItem>;
+    /**
+     * Should the user be prevented from changing the value of the input?
+     */
+    readonly readOnly?: boolean;
+  };
 
 export class SettingListItem<TSetting extends Setting = Setting> extends LabelListItem {
   declare readonly _options: SettingListItemOptions;

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -80,15 +80,15 @@ export class SettingListItem<TSetting extends Setting = Setting> extends LabelLi
     this.addChildren(options?.children);
   }
 
-  check(isBatchProcess = false) {
+  async check(isBatchProcess = false) {
     this.setting.enabled = true;
-    this._options?.onCheck?.call(isBatchProcess);
+    await this._options?.onCheck?.call(isBatchProcess);
     this.refreshUi();
   }
 
-  uncheck(isBatchProcess = false) {
+  async uncheck(isBatchProcess = false) {
     this.setting.enabled = false;
-    this._options.onUnCheck?.call(isBatchProcess);
+    await this._options.onUnCheck?.call(isBatchProcess);
     this.refreshUi();
   }
 

--- a/source/ui/components/SettingListItem.ts
+++ b/source/ui/components/SettingListItem.ts
@@ -9,12 +9,12 @@ export type SettingListItemOptions = ThisType<SettingListItem> &
     /**
      * Will be invoked when the user checks the checkbox.
      */
-    readonly onCheck?: (isBatchProcess?: boolean) => void;
+    readonly onCheck?: (isBatchProcess?: boolean) => void | Promise<void>;
 
     /**
      * Will be invoked when the user unchecks the checkbox.
      */
-    readonly onUnCheck?: (isBatchProcess?: boolean) => void;
+    readonly onUnCheck?: (isBatchProcess?: boolean) => void | Promise<void>;
 
     /**
      * Should the user be prevented from changing the value of the input?

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -3,17 +3,15 @@ import type { SettingMax } from "../../settings/Settings.js";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
-import type { UiComponent } from "./UiComponent.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 
-export type SettingMaxListItemOptions = SettingListItemOptions<UiComponent> & {
-  readonly onRefreshMax: (subject: SettingMaxListItem) => void;
-  readonly onSetMax: (subject: SettingMaxListItem) => void;
+export type SettingMaxListItemOptions = SettingListItemOptions & {
+  readonly onRefreshMax?: (subject: SettingMaxListItem) => void;
+  readonly onSetMax?: (subject: SettingMaxListItem) => void;
 };
 
-export class SettingMaxListItem<
-  TOptions extends SettingMaxListItemOptions = SettingMaxListItemOptions,
-> extends SettingListItem<SettingMax> {
+export class SettingMaxListItem extends SettingListItem<SettingMax> {
+  declare readonly _options: SettingMaxListItemOptions;
   readonly maxButton: MaxButton;
 
   /**
@@ -30,7 +28,7 @@ export class SettingMaxListItem<
     host: KittenScientists,
     setting: SettingMax,
     label: string,
-    options?: Partial<TOptions>,
+    options?: SettingMaxListItemOptions,
   ) {
     super(host, setting, label, options);
 

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -8,7 +8,7 @@ import { MaxButton } from "./buttons/MaxButton.js";
 export type SettingMaxListItemOptions = ThisType<SettingMaxListItem> &
   SettingListItemOptions & {
     readonly onRefreshMax?: () => void;
-    readonly onSetMax?: () => void;
+    readonly onSetMax: () => void;
   };
 
 export class SettingMaxListItem extends SettingListItem<SettingMax> {
@@ -29,13 +29,13 @@ export class SettingMaxListItem extends SettingListItem<SettingMax> {
     parent: UiComponent,
     setting: SettingMax,
     label: string,
-    options?: SettingMaxListItemOptions,
+    options: SettingMaxListItemOptions,
   ) {
     super(parent, setting, label, options);
 
     this.maxButton = new MaxButton(parent, setting, {
       border: false,
-      onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
+      onClick: () => options.onSetMax.call(this),
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.addChildrenHead([

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -35,7 +35,10 @@ export class SettingMaxListItem extends SettingListItem<SettingMax> {
 
     this.maxButton = new MaxButton(parent, setting, {
       border: false,
-      onClick: () => options.onSetMax.call(this),
+      onClick: () => {
+        options.onSetMax.call(this);
+        this.requestRefresh();
+      },
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.addChildrenHead([

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -8,7 +8,7 @@ import { MaxButton } from "./buttons/MaxButton.js";
 export type SettingMaxListItemOptions = SettingListItemOptions & {
   readonly onRefreshMax?: (subject: SettingMaxListItem) => void;
   readonly onSetMax?: (subject: SettingMaxListItem) => void;
-};
+} & ThisType<SettingMaxListItem>;
 
 export class SettingMaxListItem extends SettingListItem<SettingMax> {
   declare readonly _options: SettingMaxListItemOptions;

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -6,14 +6,13 @@ import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.
 import type { UiComponent } from "./UiComponent.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 
-export type SettingListItemOptionsMax = {
+export type SettingMaxListItemOptions = SettingListItemOptions<UiComponent> & {
   readonly onRefreshMax: (subject: SettingMaxListItem) => void;
   readonly onSetMax: (subject: SettingMaxListItem) => void;
 };
 
 export class SettingMaxListItem<
-  TOptions extends SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsMax = SettingListItemOptions<UiComponent> & SettingListItemOptionsMax,
+  TOptions extends SettingMaxListItemOptions = SettingMaxListItemOptions,
 > extends SettingListItem<SettingMax> {
   readonly maxButton: MaxButton;
 

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -48,6 +48,6 @@ export class SettingMaxListItem extends SettingListItem<SettingMax> {
   }
 
   toString(): string {
-    return `[${SettingMaxListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${SettingMaxListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 }

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -38,15 +38,13 @@ export class SettingMaxListItem extends SettingListItem<SettingMax> {
       onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
-    this.head.addChildren([
+    this.addChildrenHead([
       new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.maxButton,
     ]);
   }
 
-  refreshUi() {
-    super.refreshUi();
-
-    this.maxButton.refreshUi();
+  toString(): string {
+    return `[${SettingMaxListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 }

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -5,10 +5,11 @@ import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 
-export type SettingMaxListItemOptions = SettingListItemOptions & {
-  readonly onRefreshMax?: (subject: SettingMaxListItem) => void;
-  readonly onSetMax?: (subject: SettingMaxListItem) => void;
-} & ThisType<SettingMaxListItem>;
+export type SettingMaxListItemOptions = ThisType<SettingMaxListItem> &
+  SettingListItemOptions & {
+    readonly onRefreshMax?: () => void;
+    readonly onSetMax?: () => void;
+  };
 
 export class SettingMaxListItem extends SettingListItem<SettingMax> {
   declare readonly _options: SettingMaxListItemOptions;
@@ -34,8 +35,8 @@ export class SettingMaxListItem extends SettingListItem<SettingMax> {
 
     this.maxButton = new MaxButton(host, setting, {
       border: false,
-      onClick: options?.onSetMax ? () => options.onSetMax?.(this) : undefined,
-      onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.(this) : undefined,
+      onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
+      onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.head.addChildren([
       new Container(host, { classes: [stylesLabelListItem.fillSpace] }),

--- a/source/ui/components/SettingMaxListItem.ts
+++ b/source/ui/components/SettingMaxListItem.ts
@@ -1,8 +1,8 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingMax } from "../../settings/Settings.js";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 
 export type SettingMaxListItemOptions = ThisType<SettingMaxListItem> &
@@ -12,7 +12,7 @@ export type SettingMaxListItemOptions = ThisType<SettingMaxListItem> &
   };
 
 export class SettingMaxListItem extends SettingListItem<SettingMax> {
-  declare readonly _options: SettingMaxListItemOptions;
+  declare readonly options: SettingMaxListItemOptions;
   readonly maxButton: MaxButton;
 
   /**
@@ -26,20 +26,20 @@ export class SettingMaxListItem extends SettingListItem<SettingMax> {
    * @param options Options for the list item.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingMax,
     label: string,
     options?: SettingMaxListItemOptions,
   ) {
-    super(host, setting, label, options);
+    super(parent, setting, label, options);
 
-    this.maxButton = new MaxButton(host, setting, {
+    this.maxButton = new MaxButton(parent, setting, {
       border: false,
       onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.head.addChildren([
-      new Container(host, { classes: [stylesLabelListItem.fillSpace] }),
+      new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.maxButton,
     ]);
   }

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -5,18 +5,18 @@ import stylesButton from "./Button.module.css";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
-import type { SettingListItemOptionsMax } from "./SettingMaxListItem.js";
-import type { SettingListItemOptionsTrigger } from "./SettingTriggerListItem.js";
+import type { SettingMaxListItemOptions } from "./SettingMaxListItem.js";
+import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
 import type { UiComponent } from "./UiComponent.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
+export type SettingMaxTriggerListItemOptions = SettingListItemOptions<UiComponent> &
+  SettingMaxListItemOptions &
+  SettingTriggerListItemOptions;
+
 export class SettingMaxTriggerListItem<
-  TOptions extends SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsMax &
-    SettingListItemOptionsTrigger = SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsMax &
-    SettingListItemOptionsTrigger,
+  TOptions extends SettingMaxTriggerListItemOptions = SettingMaxTriggerListItemOptions,
 > extends SettingListItem<SettingTriggerMax, TOptions> {
   readonly maxButton: MaxButton;
   readonly triggerButton: TriggerButton;

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../../Engine.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingOptions, SettingTriggerMax } from "../../settings/Settings.js";
 import stylesButton from "./Button.module.css";
 import { Container } from "./Container.js";
@@ -7,6 +6,7 @@ import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import type { SettingMaxListItemOptions } from "./SettingMaxListItem.js";
 import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
@@ -16,27 +16,27 @@ export type SettingMaxTriggerListItemOptions = ThisType<SettingMaxTriggerListIte
   SettingTriggerListItemOptions;
 
 export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax> {
-  declare readonly _options: SettingMaxTriggerListItemOptions;
+  declare readonly options: SettingMaxTriggerListItemOptions;
   readonly maxButton: MaxButton;
   readonly triggerButton: TriggerButton;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingTriggerMax,
     locale: SettingOptions<SupportedLocale>,
     label: string,
     options?: SettingMaxTriggerListItemOptions,
   ) {
-    super(host, setting, label, options);
+    super(parent, setting, label, options);
 
-    this.maxButton = new MaxButton(host, setting, {
+    this.maxButton = new MaxButton(parent, setting, {
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
       onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
-    this.triggerButton = new TriggerButton(host, setting, locale, {
+    this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
       onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
@@ -46,7 +46,7 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
     });
 
     this.head.addChildren([
-      new Container(host, { classes: [stylesLabelListItem.fillSpace] }),
+      new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.maxButton,
       this.triggerButton,
     ]);

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -10,10 +10,10 @@ import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js"
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type SettingMaxTriggerListItemOptions = SettingListItemOptions &
+export type SettingMaxTriggerListItemOptions = ThisType<SettingMaxTriggerListItem> &
+  SettingListItemOptions &
   SettingMaxListItemOptions &
-  SettingTriggerListItemOptions &
-  ThisType<SettingMaxTriggerListItem>;
+  SettingTriggerListItemOptions;
 
 export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax> {
   declare readonly _options: SettingMaxTriggerListItemOptions;
@@ -33,15 +33,15 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
-      onClick: options?.onSetMax ? () => options.onSetMax?.(this) : undefined,
-      onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.(this) : undefined,
+      onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
+      onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.triggerButton = new TriggerButton(host, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.(this) : undefined,
+      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
       onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.(this)
+        ? () => options.onRefreshTrigger?.call(this)
         : undefined,
     });
 

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -7,17 +7,15 @@ import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import type { SettingMaxListItemOptions } from "./SettingMaxListItem.js";
 import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
-import type { UiComponent } from "./UiComponent.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type SettingMaxTriggerListItemOptions = SettingListItemOptions<UiComponent> &
+export type SettingMaxTriggerListItemOptions = SettingListItemOptions &
   SettingMaxListItemOptions &
   SettingTriggerListItemOptions;
 
-export class SettingMaxTriggerListItem<
-  TOptions extends SettingMaxTriggerListItemOptions = SettingMaxTriggerListItemOptions,
-> extends SettingListItem<SettingTriggerMax, TOptions> {
+export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax> {
+  declare readonly _options: SettingMaxTriggerListItemOptions;
   readonly maxButton: MaxButton;
   readonly triggerButton: TriggerButton;
 
@@ -26,7 +24,7 @@ export class SettingMaxTriggerListItem<
     setting: SettingTriggerMax,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: Partial<TOptions>,
+    options?: SettingMaxTriggerListItemOptions,
   ) {
     super(host, setting, label, options);
 

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -12,7 +12,8 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 
 export type SettingMaxTriggerListItemOptions = SettingListItemOptions &
   SettingMaxListItemOptions &
-  SettingTriggerListItemOptions;
+  SettingTriggerListItemOptions &
+  ThisType<SettingMaxTriggerListItem>;
 
 export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax> {
   declare readonly _options: SettingMaxTriggerListItemOptions;

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -13,7 +13,9 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 export type SettingMaxTriggerListItemOptions = ThisType<SettingMaxTriggerListItem> &
   SettingListItemOptions &
   SettingMaxListItemOptions &
-  SettingTriggerListItemOptions;
+  SettingTriggerListItemOptions & {
+    readonly renderLabelTrigger?: boolean;
+  };
 
 export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax> {
   declare readonly options: SettingMaxTriggerListItemOptions;
@@ -42,11 +44,12 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: () => {
-        options.onSetTrigger.call(this);
+      onClick: async () => {
+        await options.onSetTrigger.call(this);
         this.requestRefresh();
       },
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
+      renderLabel: options?.renderLabelTrigger ?? true,
     });
 
     this.addChildrenHead([
@@ -57,6 +60,6 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
   }
 
   toString(): string {
-    return `[${SettingMaxTriggerListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${SettingMaxTriggerListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 }

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -25,7 +25,7 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
     setting: SettingTriggerMax,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: SettingMaxTriggerListItemOptions,
+    options: SettingMaxTriggerListItemOptions,
   ) {
     super(parent, setting, label, options);
 
@@ -33,13 +33,13 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
-      onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
+      onClick: () => options.onSetMax.call(this),
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
+      onClick: () => options.onSetTrigger.call(this),
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
 

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -33,13 +33,19 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
-      onClick: () => options.onSetMax.call(this),
+      onClick: () => {
+        options.onSetMax.call(this);
+        this.requestRefresh();
+      },
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: () => options.onSetTrigger.call(this),
+      onClick: () => {
+        options.onSetTrigger.call(this);
+        this.requestRefresh();
+      },
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
 

--- a/source/ui/components/SettingMaxTriggerListItem.ts
+++ b/source/ui/components/SettingMaxTriggerListItem.ts
@@ -40,19 +40,17 @@ export class SettingMaxTriggerListItem extends SettingListItem<SettingTriggerMax
       border: false,
       classes: [stylesButton.lastHeadAction],
       onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
-      onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.call(this)
-        : undefined,
+      onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
 
-    this.head.addChildren([
+    this.addChildrenHead([
       new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.maxButton,
       this.triggerButton,
     ]);
   }
 
-  override refreshUi(): void {
-    super.refreshUi();
+  toString(): string {
+    return `[${SettingMaxTriggerListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 }

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -7,15 +7,14 @@ import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.
 import type { UiComponent } from "./UiComponent.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type SettingListItemOptionsTrigger = {
+export type SettingTriggerListItemOptions = SettingListItemOptions<UiComponent> & {
   readonly onRefreshTrigger: (subject: SettingTriggerListItem) => void;
   readonly onSetTrigger: (subject: SettingTriggerListItem) => void;
 };
 
 export class SettingTriggerListItem<
-  TOptions extends SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsTrigger = SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsTrigger,
+  TOptions extends SettingTriggerListItemOptions &
+    SettingTriggerListItemOptions = SettingTriggerListItemOptions,
 > extends SettingListItem {
   readonly triggerButton: TriggerButton;
 

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -4,18 +4,15 @@ import type { SettingOptions, SettingThreshold, SettingTrigger } from "../../set
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
-import type { UiComponent } from "./UiComponent.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type SettingTriggerListItemOptions = SettingListItemOptions<UiComponent> & {
-  readonly onRefreshTrigger: (subject: SettingTriggerListItem) => void;
-  readonly onSetTrigger: (subject: SettingTriggerListItem) => void;
+export type SettingTriggerListItemOptions = SettingListItemOptions & {
+  readonly onRefreshTrigger?: (subject: SettingTriggerListItem) => void;
+  readonly onSetTrigger: (subject: SettingTriggerListItem) => unknown | Promise<unknown>;
 };
 
-export class SettingTriggerListItem<
-  TOptions extends SettingTriggerListItemOptions &
-    SettingTriggerListItemOptions = SettingTriggerListItemOptions,
-> extends SettingListItem {
+export class SettingTriggerListItem extends SettingListItem {
+  declare readonly _options: SettingTriggerListItemOptions;
   readonly triggerButton: TriggerButton;
 
   constructor(
@@ -23,14 +20,17 @@ export class SettingTriggerListItem<
     setting: SettingThreshold | SettingTrigger,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: Partial<TOptions>,
+    options: SettingTriggerListItemOptions,
   ) {
     super(host, setting, label, options);
 
     this.triggerButton = new TriggerButton(host, setting, locale, {
       alignment: "right",
       border: false,
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.(this) : undefined,
+      onClick: (event?: MouseEvent) => {
+        this._options.onSetTrigger(this);
+        this.refreshUi();
+      },
       onRefreshTitle: options?.onRefreshTrigger
         ? () => options.onRefreshTrigger?.(this)
         : undefined,

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -28,8 +28,8 @@ export class SettingTriggerListItem extends SettingListItem {
     this.triggerButton = new TriggerButton(host, setting, locale, {
       alignment: "right",
       border: false,
-      onClick: (event?: MouseEvent) => {
-        this._options.onSetTrigger.call(this);
+      onClick: async (event?: MouseEvent) => {
+        await this._options.onSetTrigger.call(this);
         this.refreshUi();
       },
       onRefreshTitle: options?.onRefreshTrigger

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -8,8 +8,8 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 
 export type SettingTriggerListItemOptions = ThisType<SettingTriggerListItem> &
   SettingListItemOptions & {
-    readonly onRefreshTrigger?: () => unknown | Promise<unknown>;
-    readonly onSetTrigger: () => unknown | Promise<unknown>;
+    readonly onRefreshTrigger?: () => void | Promise<void>;
+    readonly onSetTrigger: () => void | Promise<void>;
   };
 
 export class SettingTriggerListItem extends SettingListItem {

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -28,7 +28,7 @@ export class SettingTriggerListItem extends SettingListItem {
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       alignment: "right",
       border: false,
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
+      onClick: () => options.onSetTrigger.call(this),
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
     this.addChildrenHead([

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -9,7 +9,7 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 export type SettingTriggerListItemOptions = SettingListItemOptions & {
   readonly onRefreshTrigger?: (subject: SettingTriggerListItem) => void;
   readonly onSetTrigger: (subject: SettingTriggerListItem) => unknown | Promise<unknown>;
-};
+} & ThisType<SettingTriggerListItem>;
 
 export class SettingTriggerListItem extends SettingListItem {
   declare readonly _options: SettingTriggerListItemOptions;

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -8,7 +8,7 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 
 export type SettingTriggerListItemOptions = ThisType<SettingTriggerListItem> &
   SettingListItemOptions & {
-    readonly onRefreshTrigger?: () => void;
+    readonly onRefreshTrigger?: () => unknown | Promise<unknown>;
     readonly onSetTrigger: () => unknown | Promise<unknown>;
   };
 

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -6,10 +6,11 @@ import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type SettingTriggerListItemOptions = SettingListItemOptions & {
-  readonly onRefreshTrigger?: (subject: SettingTriggerListItem) => void;
-  readonly onSetTrigger: (subject: SettingTriggerListItem) => unknown | Promise<unknown>;
-} & ThisType<SettingTriggerListItem>;
+export type SettingTriggerListItemOptions = ThisType<SettingTriggerListItem> &
+  SettingListItemOptions & {
+    readonly onRefreshTrigger?: () => void;
+    readonly onSetTrigger: () => unknown | Promise<unknown>;
+  };
 
 export class SettingTriggerListItem extends SettingListItem {
   declare readonly _options: SettingTriggerListItemOptions;
@@ -28,11 +29,11 @@ export class SettingTriggerListItem extends SettingListItem {
       alignment: "right",
       border: false,
       onClick: (event?: MouseEvent) => {
-        this._options.onSetTrigger(this);
+        this._options.onSetTrigger.call(this);
         this.refreshUi();
       },
       onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.(this)
+        ? () => options.onRefreshTrigger?.call(this)
         : undefined,
     });
     this.head.addChild(new Container(host, { classes: [stylesLabelListItem.fillSpace] }));

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -10,6 +10,7 @@ export type SettingTriggerListItemOptions = ThisType<SettingTriggerListItem> &
   SettingListItemOptions & {
     readonly onRefreshTrigger?: () => void | Promise<void>;
     readonly onSetTrigger: () => void | Promise<void>;
+    readonly renderLabelTrigger?: boolean;
   };
 
 export class SettingTriggerListItem extends SettingListItem {
@@ -28,8 +29,12 @@ export class SettingTriggerListItem extends SettingListItem {
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       alignment: "right",
       border: false,
-      onClick: () => options.onSetTrigger.call(this),
+      onClick: async () => {
+        await options.onSetTrigger.call(this);
+        this.requestRefresh();
+      },
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
+      renderLabel: options?.renderLabelTrigger ?? true,
     });
     this.addChildrenHead([
       new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
@@ -38,6 +43,6 @@ export class SettingTriggerListItem extends SettingListItem {
   }
 
   toString(): string {
-    return `[${SettingTriggerListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
+    return `[${SettingTriggerListItem.name}#${this.componentId}]: '${this.elementLabel.text()}'`;
   }
 }

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -1,9 +1,9 @@
 import type { SupportedLocale } from "../../Engine.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingOptions, SettingThreshold, SettingTrigger } from "../../settings/Settings.js";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
 export type SettingTriggerListItemOptions = ThisType<SettingTriggerListItem> &
@@ -13,30 +13,30 @@ export type SettingTriggerListItemOptions = ThisType<SettingTriggerListItem> &
   };
 
 export class SettingTriggerListItem extends SettingListItem {
-  declare readonly _options: SettingTriggerListItemOptions;
+  declare readonly options: SettingTriggerListItemOptions;
   readonly triggerButton: TriggerButton;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingThreshold | SettingTrigger,
     locale: SettingOptions<SupportedLocale>,
     label: string,
     options: SettingTriggerListItemOptions,
   ) {
-    super(host, setting, label, options);
+    super(parent, setting, label, options);
 
-    this.triggerButton = new TriggerButton(host, setting, locale, {
+    this.triggerButton = new TriggerButton(parent, setting, locale, {
       alignment: "right",
       border: false,
       onClick: async (event?: MouseEvent) => {
-        await this._options.onSetTrigger.call(this);
+        await this.options.onSetTrigger.call(this);
         this.refreshUi();
       },
       onRefreshTitle: options?.onRefreshTrigger
         ? () => options.onRefreshTrigger?.call(this)
         : undefined,
     });
-    this.head.addChild(new Container(host, { classes: [stylesLabelListItem.fillSpace] }));
+    this.head.addChild(new Container(parent, { classes: [stylesLabelListItem.fillSpace] }));
     this.head.addChild(this.triggerButton);
   }
 

--- a/source/ui/components/SettingTriggerListItem.ts
+++ b/source/ui/components/SettingTriggerListItem.ts
@@ -28,21 +28,16 @@ export class SettingTriggerListItem extends SettingListItem {
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       alignment: "right",
       border: false,
-      onClick: async (event?: MouseEvent) => {
-        await this.options.onSetTrigger.call(this);
-        this.refreshUi();
-      },
-      onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.call(this)
-        : undefined,
+      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
+      onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
-    this.head.addChild(new Container(parent, { classes: [stylesLabelListItem.fillSpace] }));
-    this.head.addChild(this.triggerButton);
+    this.addChildrenHead([
+      new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
+      this.triggerButton,
+    ]);
   }
 
-  refreshUi() {
-    super.refreshUi();
-
-    this.triggerButton.refreshUi();
+  toString(): string {
+    return `[${SettingTriggerListItem.name}#${this.componentId}]: ${this.elementLabel.text()}`;
   }
 }

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -12,7 +12,7 @@ export type SettingsListOptions = UiComponentOptions & {
   readonly onEnableAll?: () => void;
   readonly onDisableAll?: () => void;
   readonly onReset?: () => void;
-};
+} & ThisType<SettingsList>;
 
 /**
  * The `SettingsList` is a `<ul>` designed to host `SettingListItem` instances.

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -23,6 +23,7 @@ export type SettingsListOptions = UiComponentOptions & {
  * This construct is also sometimes referred to as an "items list" for historic reasons.
  */
 export class SettingsList extends UiComponent {
+  declare readonly _options: SettingsListOptions;
   readonly element: JQuery;
   readonly list: JQuery;
 

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -38,7 +38,7 @@ export class SettingsList extends UiComponent {
    * @param options Which tools should be available on the list?
    */
   constructor(parent: UiComponent, options?: SettingsListOptions) {
-    super(parent, { ...options, children: [] });
+    super(parent, { ...options });
 
     const toolOptions = {
       hasDisableAll: true,
@@ -80,8 +80,6 @@ export class SettingsList extends UiComponent {
               if (!isNil(onEnableAll)) {
                 onEnableAll();
               }
-
-              this.refreshUi();
             },
           },
         );
@@ -110,8 +108,6 @@ export class SettingsList extends UiComponent {
           if (!isNil(onDisableAll)) {
             onDisableAll();
           }
-
-          this.refreshUi();
         });
         tools.append(this.disableAllButton.element);
       }
@@ -135,11 +131,17 @@ export class SettingsList extends UiComponent {
     }
 
     this.element = container;
-    this.addChildren(options?.children);
   }
 
-  override addChild(child: UiComponent) {
+  toString(): string {
+    return `[${SettingsList.name}#${this.componentId}]`;
+  }
+
+  override addChild(child: UiComponent): this {
     this.children.add(child);
     this.list.append(child.element);
+    return this;
   }
+
+  refreshUi() {}
 }

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -6,13 +6,14 @@ import { SettingListItem } from "./SettingListItem.js";
 import styles from "./SettingsList.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type SettingsListOptions = UiComponentOptions & {
-  readonly hasEnableAll?: boolean;
-  readonly hasDisableAll?: boolean;
-  readonly onEnableAll?: () => void;
-  readonly onDisableAll?: () => void;
-  readonly onReset?: () => void;
-} & ThisType<SettingsList>;
+export type SettingsListOptions = ThisType<SettingsList> &
+  UiComponentOptions & {
+    readonly hasEnableAll?: boolean;
+    readonly hasDisableAll?: boolean;
+    readonly onEnableAll?: () => void;
+    readonly onDisableAll?: () => void;
+    readonly onReset?: () => void;
+  };
 
 /**
  * The `SettingsList` is a `<ul>` designed to host `SettingListItem` instances.

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -1,5 +1,4 @@
 import { is, isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import { Icons } from "../../images/Icons.js";
 import { IconButton } from "./IconButton.js";
 import { SettingListItem } from "./SettingListItem.js";
@@ -24,7 +23,7 @@ export type SettingsListOptions = ThisType<SettingsList> &
  * This construct is also sometimes referred to as an "items list" for historic reasons.
  */
 export class SettingsList extends UiComponent {
-  declare readonly _options: SettingsListOptions;
+  declare readonly options: SettingsListOptions;
   readonly element: JQuery;
   readonly list: JQuery;
 
@@ -38,8 +37,8 @@ export class SettingsList extends UiComponent {
    * @param host A reference to the host.
    * @param options Which tools should be available on the list?
    */
-  constructor(host: KittenScientists, options?: SettingsListOptions) {
-    super(host, { ...options, children: [] });
+  constructor(parent: UiComponent, options?: SettingsListOptions) {
+    super(parent, { ...options, children: [] });
 
     const toolOptions = {
       hasDisableAll: true,
@@ -61,9 +60,9 @@ export class SettingsList extends UiComponent {
       if (toolOptions.hasEnableAll) {
         const onEnableAll = options?.onEnableAll;
         this.enableAllButton = new IconButton(
-          this._host,
+          parent,
           Icons.CheckboxCheck,
-          host.engine.i18n("ui.enable.all"),
+          parent.host.engine.i18n("ui.enable.all"),
           {
             onClick: () => {
               const event = new Event("enableAll", { cancelable: true });
@@ -92,9 +91,9 @@ export class SettingsList extends UiComponent {
       if (toolOptions.hasDisableAll) {
         const onDisableAll = options?.onDisableAll;
         this.disableAllButton = new IconButton(
-          this._host,
+          parent,
           Icons.CheckboxUnCheck,
-          host.engine.i18n("ui.disable.all"),
+          parent.host.engine.i18n("ui.disable.all"),
         );
         this.disableAllButton.element.on("click", () => {
           const event = new Event("disableAll", { cancelable: true });
@@ -119,11 +118,16 @@ export class SettingsList extends UiComponent {
 
       const onReset = toolOptions.onReset;
       if (!isNil(onReset)) {
-        this.resetButton = new IconButton(this._host, Icons.Reset, host.engine.i18n("ui.reset"), {
-          onClick: () => {
-            onReset();
+        this.resetButton = new IconButton(
+          parent,
+          Icons.Reset,
+          parent.host.engine.i18n("ui.reset"),
+          {
+            onClick: () => {
+              onReset();
+            },
           },
-        });
+        );
         tools.append(this.resetButton.element);
       }
 

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -4,16 +4,15 @@ import { Icons } from "../../images/Icons.js";
 import { IconButton } from "./IconButton.js";
 import { SettingListItem } from "./SettingListItem.js";
 import styles from "./SettingsList.module.css";
-import { UiComponent, type UiComponentInterface, type UiComponentOptions } from "./UiComponent.js";
+import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type SettingsListOptions<TChild extends UiComponentInterface = UiComponentInterface> =
-  UiComponentOptions<TChild> & {
-    readonly hasEnableAll: boolean;
-    readonly hasDisableAll: boolean;
-    readonly onEnableAll: () => void;
-    readonly onDisableAll: () => void;
-    readonly onReset: () => void;
-  };
+export type SettingsListOptions = UiComponentOptions & {
+  readonly hasEnableAll?: boolean;
+  readonly hasDisableAll?: boolean;
+  readonly onEnableAll?: () => void;
+  readonly onDisableAll?: () => void;
+  readonly onReset?: () => void;
+};
 
 /**
  * The `SettingsList` is a `<ul>` designed to host `SettingListItem` instances.
@@ -23,9 +22,7 @@ export type SettingsListOptions<TChild extends UiComponentInterface = UiComponen
  *
  * This construct is also sometimes referred to as an "items list" for historic reasons.
  */
-export class SettingsList<
-  TOptions extends SettingsListOptions<UiComponent> = SettingsListOptions<UiComponent>,
-> extends UiComponent<TOptions> {
+export class SettingsList extends UiComponent {
   readonly element: JQuery;
   readonly list: JQuery;
 
@@ -39,7 +36,7 @@ export class SettingsList<
    * @param host A reference to the host.
    * @param options Which tools should be available on the list?
    */
-  constructor(host: KittenScientists, options: Partial<TOptions> = {}) {
+  constructor(host: KittenScientists, options?: SettingsListOptions) {
     super(host, { ...options, children: [] });
 
     const toolOptions = {
@@ -60,7 +57,7 @@ export class SettingsList<
       const tools = $("<div/>").addClass(styles.listTools);
 
       if (toolOptions.hasEnableAll) {
-        const onEnableAll = options.onEnableAll;
+        const onEnableAll = options?.onEnableAll;
         this.enableAllButton = new IconButton(
           this._host,
           Icons.CheckboxCheck,
@@ -91,7 +88,7 @@ export class SettingsList<
       }
 
       if (toolOptions.hasDisableAll) {
-        const onDisableAll = options.onDisableAll;
+        const onDisableAll = options?.onDisableAll;
         this.disableAllButton = new IconButton(
           this._host,
           Icons.CheckboxUnCheck,
@@ -132,7 +129,7 @@ export class SettingsList<
     }
 
     this.element = container;
-    this.addChildren(options.children);
+    this.addChildren(options?.children);
   }
 
   override addChild(child: UiComponent) {

--- a/source/ui/components/SettingsList.ts
+++ b/source/ui/components/SettingsList.ts
@@ -58,7 +58,6 @@ export class SettingsList extends UiComponent {
       const tools = $("<div/>").addClass(styles.listTools);
 
       if (toolOptions.hasEnableAll) {
-        const onEnableAll = options?.onEnableAll;
         this.enableAllButton = new IconButton(
           parent,
           Icons.CheckboxCheck,
@@ -77,9 +76,8 @@ export class SettingsList extends UiComponent {
                 }
               }
 
-              if (!isNil(onEnableAll)) {
-                onEnableAll();
-              }
+              options?.onEnableAll?.call(this);
+              this.requestRefresh();
             },
           },
         );
@@ -87,7 +85,6 @@ export class SettingsList extends UiComponent {
       }
 
       if (toolOptions.hasDisableAll) {
-        const onDisableAll = options?.onDisableAll;
         this.disableAllButton = new IconButton(
           parent,
           Icons.CheckboxUnCheck,
@@ -105,9 +102,9 @@ export class SettingsList extends UiComponent {
               (child as SettingListItem).uncheck();
             }
           }
-          if (!isNil(onDisableAll)) {
-            onDisableAll();
-          }
+
+          options?.onDisableAll?.call(this);
+          this.requestRefresh();
         });
         tools.append(this.disableAllButton.element);
       }
@@ -138,10 +135,11 @@ export class SettingsList extends UiComponent {
   }
 
   override addChild(child: UiComponent): this {
+    child.parent = this;
     this.children.add(child);
     this.list.append(child.element);
     return this;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -68,6 +68,6 @@ export class SettingsPanel<
   }
 
   toString(): string {
-    return `[${SettingsPanel.name}#${this.componentId}]: ${this.settingItem.elementLabel.text()}`;
+    return `[${SettingsPanel.name}#${this.componentId}]: '${this.settingItem.elementLabel.text()}'`;
   }
 }

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -15,6 +15,7 @@ export class SettingsPanel<
   extends CollapsiblePanel
   implements SettingListItem
 {
+  declare readonly _options: SettingsPanelOptions<TListItem>;
   readonly setting: TSetting;
   readonly settingItem: TListItem;
 
@@ -59,7 +60,7 @@ export class SettingsPanel<
     host: KittenScientists,
     setting: TSetting,
     settingItem: TListItem,
-    options?: Partial<SettingsPanelOptions<TListItem>>,
+    options?: SettingsPanelOptions<TListItem>,
   ) {
     super(host, settingItem, options);
 

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -39,12 +39,12 @@ export class SettingsPanel<
 
   async check() {
     this.setting.enabled = true;
-    this.refreshUi();
+    this.requestRefresh();
   }
 
   async uncheck() {
     this.setting.enabled = false;
-    this.refreshUi();
+    this.requestRefresh();
   }
 
   /**

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -27,10 +27,7 @@ export class SettingsPanel<
 
   // SettingListItem interface
   get elementLabel() {
-    return this._head.element;
-  }
-  get head() {
-    return this._head;
+    return this.head.element;
   }
 
   get readOnly() {
@@ -68,5 +65,9 @@ export class SettingsPanel<
 
     this.settingItem = settingItem;
     this.setting = setting;
+  }
+
+  toString(): string {
+    return `[${SettingsPanel.name}#${this.componentId}]: ${this.settingItem.elementLabel.text()}`;
   }
 }

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -1,8 +1,8 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
 import { CollapsiblePanel, type CollapsiblePanelOptions } from "./CollapsiblePanel.js";
 import type { LabelListItem } from "./LabelListItem.js";
 import type { SettingListItem } from "./SettingListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 
 export type SettingsPanelOptions<TListItem extends LabelListItem = LabelListItem> =
   ThisType<SettingsPanel> &
@@ -17,7 +17,7 @@ export class SettingsPanel<
   extends CollapsiblePanel
   implements SettingListItem
 {
-  declare readonly _options: SettingsPanelOptions<TListItem>;
+  declare readonly options: SettingsPanelOptions<TListItem>;
   readonly setting: TSetting;
   readonly settingItem: TListItem;
 
@@ -59,12 +59,12 @@ export class SettingsPanel<
    * @param options - Options for this panel.
    */
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: TSetting,
     settingItem: TListItem,
     options?: SettingsPanelOptions<TListItem>,
   ) {
-    super(host, settingItem, options);
+    super(parent, settingItem, options);
 
     this.settingItem = settingItem;
     this.setting = setting;

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -1,12 +1,13 @@
 import type { KittenScientists } from "../../KittenScientists.js";
 import type { Setting } from "../../settings/Settings.js";
-import { CollapsiblePanel, type PanelOptions } from "./CollapsiblePanel.js";
+import { CollapsiblePanel, type CollapsiblePanelOptions } from "./CollapsiblePanel.js";
 import type { LabelListItem } from "./LabelListItem.js";
 import type { SettingListItem } from "./SettingListItem.js";
 
-export type SettingsPanelOptions<TListItem extends LabelListItem = LabelListItem> = PanelOptions & {
-  readonly settingItem: TListItem;
-};
+export type SettingsPanelOptions<TListItem extends LabelListItem = LabelListItem> =
+  CollapsiblePanelOptions & {
+    readonly settingItem?: TListItem;
+  } & ThisType<SettingsPanel>;
 
 export class SettingsPanel<
     TSetting extends Setting = Setting,

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -5,9 +5,10 @@ import type { LabelListItem } from "./LabelListItem.js";
 import type { SettingListItem } from "./SettingListItem.js";
 
 export type SettingsPanelOptions<TListItem extends LabelListItem = LabelListItem> =
-  CollapsiblePanelOptions & {
-    readonly settingItem?: TListItem;
-  } & ThisType<SettingsPanel>;
+  ThisType<SettingsPanel> &
+    CollapsiblePanelOptions & {
+      readonly settingItem?: TListItem;
+    };
 
 export class SettingsPanel<
     TSetting extends Setting = Setting,

--- a/source/ui/components/SettingsPanel.ts
+++ b/source/ui/components/SettingsPanel.ts
@@ -40,12 +40,12 @@ export class SettingsPanel<
     /* noop */
   }
 
-  check() {
+  async check() {
     this.setting.enabled = true;
     this.refreshUi();
   }
 
-  uncheck() {
+  async uncheck() {
     this.setting.enabled = false;
     this.refreshUi();
   }

--- a/source/ui/components/TextButton.ts
+++ b/source/ui/components/TextButton.ts
@@ -6,18 +6,14 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type TextButtonOptions = UiComponentOptions & {
   readonly title?: string;
-};
+} & ThisType<TextButton>;
 
 export class TextButton extends UiComponent {
   declare readonly _options: TextButtonOptions;
   readonly element: JQuery;
   readOnly: boolean;
 
-  constructor(
-    host: KittenScientists,
-    label?: string,
-    options?: TextButtonOptions & ThisType<TextButton>,
-  ) {
+  constructor(host: KittenScientists, label?: string, options?: TextButtonOptions) {
     super(host, { ...options });
 
     const element = $("<div/>").addClass(styles.textButton);

--- a/source/ui/components/TextButton.ts
+++ b/source/ui/components/TextButton.ts
@@ -1,5 +1,4 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import stylesButton from "./Button.module.css";
 import styles from "./TextButton.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
@@ -10,12 +9,12 @@ export type TextButtonOptions = ThisType<TextButton> &
   };
 
 export class TextButton extends UiComponent {
-  declare readonly _options: TextButtonOptions;
+  declare readonly options: TextButtonOptions;
   readonly element: JQuery;
   readOnly: boolean;
 
-  constructor(host: KittenScientists, label?: string, options?: TextButtonOptions) {
-    super(host, { ...options });
+  constructor(parent: UiComponent, label?: string, options?: TextButtonOptions) {
+    super(parent, { ...options });
 
     const element = $("<div/>").addClass(styles.textButton);
     if (label !== undefined) {

--- a/source/ui/components/TextButton.ts
+++ b/source/ui/components/TextButton.ts
@@ -4,9 +4,10 @@ import stylesButton from "./Button.module.css";
 import styles from "./TextButton.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
-export type TextButtonOptions = UiComponentOptions & {
-  readonly title?: string;
-} & ThisType<TextButton>;
+export type TextButtonOptions = ThisType<TextButton> &
+  UiComponentOptions & {
+    readonly title?: string;
+  };
 
 export class TextButton extends UiComponent {
   declare readonly _options: TextButtonOptions;

--- a/source/ui/components/TextButton.ts
+++ b/source/ui/components/TextButton.ts
@@ -5,16 +5,19 @@ import styles from "./TextButton.module.css";
 import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 
 export type TextButtonOptions = UiComponentOptions & {
-  readonly title: string;
-  readonly onClick: () => void;
+  readonly title?: string;
 };
 
 export class TextButton extends UiComponent {
   readonly element: JQuery;
   readOnly: boolean;
 
-  constructor(host: KittenScientists, label?: string, options?: Partial<TextButtonOptions>) {
-    super(host, options);
+  constructor(
+    host: KittenScientists,
+    label?: string,
+    options?: TextButtonOptions & ThisType<TextButton>,
+  ) {
+    super(host, { ...options });
 
     const element = $("<div/>").addClass(styles.textButton);
     if (label !== undefined) {

--- a/source/ui/components/TextButton.ts
+++ b/source/ui/components/TextButton.ts
@@ -6,6 +6,7 @@ import { UiComponent, type UiComponentOptions } from "./UiComponent.js";
 export type TextButtonOptions = ThisType<TextButton> &
   UiComponentOptions & {
     readonly title?: string;
+    readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
   };
 
 export class TextButton extends UiComponent {
@@ -27,7 +28,6 @@ export class TextButton extends UiComponent {
     }
 
     this.element = element;
-    this.addChildren(options?.children);
     this.readOnly = false;
 
     this.element.on("click", () => {
@@ -35,17 +35,21 @@ export class TextButton extends UiComponent {
     });
   }
 
-  override click() {
+  toString(): string {
+    return `[${TextButton.name}#${this.componentId}]`;
+  }
+
+  click() {
     if (this.readOnly) {
       return;
     }
 
-    super.click();
+    this.requestRefresh();
+
+    return this.options?.onClick?.call(this);
   }
 
-  override refreshUi(): void {
-    super.refreshUi();
-
+  refreshUi(): void {
     if (this.readOnly) {
       this.element.addClass(stylesButton.readonly);
     } else {

--- a/source/ui/components/TextButton.ts
+++ b/source/ui/components/TextButton.ts
@@ -9,6 +9,7 @@ export type TextButtonOptions = UiComponentOptions & {
 };
 
 export class TextButton extends UiComponent {
+  declare readonly _options: TextButtonOptions;
   readonly element: JQuery;
   readOnly: boolean;
 

--- a/source/ui/components/ToolbarListItem.ts
+++ b/source/ui/components/ToolbarListItem.ts
@@ -8,27 +8,20 @@ export type ToolbarListItemOptions = ThisType<ToolbarListItem> & ListItemOptions
 
 export class ToolbarListItem extends ListItem {
   declare readonly options: ToolbarListItemOptions;
-  readonly buttons: Array<Button | IconButton>;
 
-  constructor(
-    parent: UiComponent,
-    buttons: Array<Button | IconButton>,
-    options?: ToolbarListItemOptions,
-  ) {
+  constructor(parent: UiComponent, options?: ToolbarListItemOptions) {
     super(parent, options);
 
     this.element.addClass(styles.toolbar);
-    this.buttons = buttons;
-    for (const button of buttons) {
-      this.element.append(button.element);
-    }
   }
 
-  refreshUi(): void {
-    super.refreshUi();
+  toString(): string {
+    return `[${ToolbarListItem.name}#${this.componentId}]`;
+  }
 
-    for (const button of this.buttons) {
-      button.refreshUi();
-    }
+  override addChild(child: Button | IconButton): this {
+    this.children.add(child);
+    this.element.append(child.element);
+    return this;
   }
 }

--- a/source/ui/components/ToolbarListItem.ts
+++ b/source/ui/components/ToolbarListItem.ts
@@ -4,14 +4,16 @@ import type { IconButton } from "./IconButton.js";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import styles from "./ToolbarListItem.module.css";
 
+export type ToolbarListItemOptions = ListItemOptions & ThisType<ToolbarListItem>;
+
 export class ToolbarListItem extends ListItem {
-  declare readonly _options: ListItemOptions;
+  declare readonly _options: ToolbarListItemOptions;
   readonly buttons: Array<Button | IconButton>;
 
   constructor(
     host: KittenScientists,
     buttons: Array<Button | IconButton>,
-    options?: ListItemOptions,
+    options?: ToolbarListItemOptions,
   ) {
     super(host, options);
 

--- a/source/ui/components/ToolbarListItem.ts
+++ b/source/ui/components/ToolbarListItem.ts
@@ -3,17 +3,15 @@ import type { Button } from "./Button.js";
 import type { IconButton } from "./IconButton.js";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import styles from "./ToolbarListItem.module.css";
-import type { UiComponent } from "./UiComponent.js";
 
-export class ToolbarListItem<
-  TOptions extends ListItemOptions<UiComponent> = ListItemOptions<UiComponent>,
-> extends ListItem {
+export class ToolbarListItem extends ListItem {
+  declare readonly _options: ListItemOptions;
   readonly buttons: Array<Button | IconButton>;
 
   constructor(
     host: KittenScientists,
     buttons: Array<Button | IconButton>,
-    options?: Partial<TOptions>,
+    options?: ListItemOptions,
   ) {
     super(host, options);
 

--- a/source/ui/components/ToolbarListItem.ts
+++ b/source/ui/components/ToolbarListItem.ts
@@ -4,7 +4,7 @@ import type { IconButton } from "./IconButton.js";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import styles from "./ToolbarListItem.module.css";
 
-export type ToolbarListItemOptions = ListItemOptions & ThisType<ToolbarListItem>;
+export type ToolbarListItemOptions = ThisType<ToolbarListItem> & ListItemOptions;
 
 export class ToolbarListItem extends ListItem {
   declare readonly _options: ToolbarListItemOptions;

--- a/source/ui/components/ToolbarListItem.ts
+++ b/source/ui/components/ToolbarListItem.ts
@@ -1,21 +1,21 @@
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { Button } from "./Button.js";
 import type { IconButton } from "./IconButton.js";
 import { ListItem, type ListItemOptions } from "./ListItem.js";
 import styles from "./ToolbarListItem.module.css";
+import type { UiComponent } from "./UiComponent.js";
 
 export type ToolbarListItemOptions = ThisType<ToolbarListItem> & ListItemOptions;
 
 export class ToolbarListItem extends ListItem {
-  declare readonly _options: ToolbarListItemOptions;
+  declare readonly options: ToolbarListItemOptions;
   readonly buttons: Array<Button | IconButton>;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     buttons: Array<Button | IconButton>,
     options?: ToolbarListItemOptions,
   ) {
-    super(host, options);
+    super(parent, options);
 
     this.element.addClass(styles.toolbar);
     this.buttons = buttons;

--- a/source/ui/components/ToolbarListItem.ts
+++ b/source/ui/components/ToolbarListItem.ts
@@ -20,8 +20,6 @@ export class ToolbarListItem extends ListItem {
   }
 
   override addChild(child: Button | IconButton): this {
-    this.children.add(child);
-    this.element.append(child.element);
-    return this;
+    return super.addChild(child);
   }
 }

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -10,7 +10,7 @@ export type UiComponentInterface = EventTarget & {
 export type UiComponentOptions = {
   readonly children?: Array<UiComponentInterface>;
   readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
-  readonly onRefresh?: () => void | Promise<void>;
+  readonly onRefresh?: () => void;
 };
 
 export abstract class UiComponent extends EventTarget implements UiComponentInterface {
@@ -48,7 +48,7 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
   }
 
   click() {
-    this._options?.onClick?.call(this);
+    return this._options?.onClick?.call(this);
   }
 
   refreshUi() {

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -9,8 +9,8 @@ export type UiComponentInterface = EventTarget & {
 
 export type UiComponentOptions = {
   readonly children?: Array<UiComponentInterface>;
-  readonly onClick?: (event?: MouseEvent) => void;
-  readonly onRefresh?: () => void;
+  readonly onClick?: (event?: MouseEvent) => void | Promise<void>;
+  readonly onRefresh?: () => void | Promise<void>;
 };
 
 export abstract class UiComponent extends EventTarget implements UiComponentInterface {

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -41,7 +41,7 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
    * @param host A reference to the host.
    * @param options The options for this component.
    */
-  constructor(host: KittenScientists, options?: UiComponentOptions & ThisType<UiComponent>) {
+  constructor(host: KittenScientists, options?: UiComponentOptions) {
     super();
     this._host = host;
     this._options = options;

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -48,7 +48,7 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
   }
 
   click() {
-    this._options?.onClick?.();
+    this._options?.onClick?.call(this);
   }
 
   refreshUi() {

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -6,7 +6,7 @@ export type UiComponentInterface = EventTarget & {
   parent: UiComponentInterface | null;
   get element(): JQuery;
   refreshUi(): void;
-  requestRefresh(withChildren?: boolean): void;
+  requestRefresh(withChildren?: boolean, depth?: number): void;
   refresh(force?: boolean): void;
 };
 
@@ -60,16 +60,16 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
   abstract toString(): string;
 
   protected _needsRefresh;
-  requestRefresh(withChildren = false) {
+  requestRefresh(withChildren = false, depth = 0) {
     if (this._needsRefresh) {
       return;
     }
-    console.debug(...cl(this.toString(), "requestRefresh"));
+    console.debug(...cl("  ".repeat(depth), this.toString(), "requestRefresh"));
     this._needsRefresh = true;
-    this.parent?.requestRefresh();
+    this.parent?.requestRefresh(false);
     if (withChildren) {
       for (const child of this.children) {
-        child.requestRefresh(withChildren);
+        child.requestRefresh(withChildren, depth + 1);
       }
     }
   }

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -61,9 +61,6 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
 
   protected _needsRefresh;
   requestRefresh(withChildren = false, depth = 0) {
-    if (this._needsRefresh) {
-      return;
-    }
     console.debug(
       ...cl(
         depth < 0 ? "⤒".repeat(depth * -1) : " ".repeat(depth),
@@ -72,12 +69,22 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
         withChildren ? "with children" : "on self",
       ),
     );
-    this._needsRefresh = true;
-    this.parent?.requestRefresh(false, depth - 1);
+
     if (withChildren) {
       for (const child of this.children) {
         child.requestRefresh(withChildren, depth + 1);
       }
+    }
+
+    if (this._needsRefresh) {
+      return;
+    }
+
+    this._needsRefresh = true;
+    this.parent?.requestRefresh(false, depth - 1);
+
+    if (depth === 0) {
+      console.info(...cl("requestRefresh() complete."));
     }
   }
   refresh(force = false, depth = 0) {
@@ -102,6 +109,9 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
     }
 
     this._needsRefresh = false;
+    if (depth === 0) {
+      console.info(...cl("refresh() complete."));
+    }
   }
 
   abstract refreshUi(): void;

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -8,7 +8,6 @@ export type UiComponentInterface = EventTarget & {
 
 export type UiComponentOptions<TChild extends UiComponentInterface = UiComponentInterface> = {
   readonly children: Array<TChild>;
-  readonly classes: Array<string>;
   readonly onClick: (subject: UiComponent) => void;
   readonly onRefresh: (subject: UiComponent) => void;
 };

--- a/source/ui/components/UiComponent.ts
+++ b/source/ui/components/UiComponent.ts
@@ -3,6 +3,7 @@ import { cl } from "../../tools/Log.js";
 
 export type UiComponentInterface = EventTarget & {
   readonly children: Iterable<UiComponentInterface>;
+  parent: UiComponentInterface | null;
   get element(): JQuery;
   refreshUi(): void;
   requestRefresh(withChildren?: boolean): void;
@@ -77,6 +78,9 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
       return;
     }
 
+    if (!force) {
+      console.debug(...cl(this.toString(), "refresh", typeof this.options?.onRefresh));
+    }
     this.options?.onRefresh?.call(this);
     this.refreshUi();
     for (const child of this.children) {
@@ -89,6 +93,7 @@ export abstract class UiComponent extends EventTarget implements UiComponentInte
   abstract refreshUi(): void;
 
   addChild(child: UiComponentInterface): this {
+    child.parent = this;
     this.children.add(child);
     this.element.append(child.element);
     return this;

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -44,16 +44,16 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
-      onClick: options?.onSetMax ? () => options.onSetMax?.(this) : undefined,
-      onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.(this) : undefined,
+      onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
+      onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
 
     this.triggerButton = new TriggerButton(host, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.(this) : undefined,
+      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
       onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.(this)
+        ? () => options.onRefreshTrigger?.call(this)
         : undefined,
     });
     this.head.addChildren([

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -6,23 +6,22 @@ import stylesButton from "./Button.module.css";
 import { Container } from "./Container.js";
 import stylesLabelListItem from "./LabelListItem.module.css";
 import stylesListItem from "./ListItem.module.css";
-import type { SettingListItemOptionsLimited } from "./SettingLimitedListItem.js";
+import type { SettingLimitedListItemOptions } from "./SettingLimitedListItem.js";
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
-import type { SettingListItemOptionsMax } from "./SettingMaxListItem.js";
-import type { SettingListItemOptionsTrigger } from "./SettingTriggerListItem.js";
+import type { SettingMaxListItemOptions } from "./SettingMaxListItem.js";
+import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
 import type { UiComponent } from "./UiComponent.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
+export type WorkshopCraftListItemOptions = SettingListItemOptions<UiComponent> &
+  SettingLimitedListItemOptions &
+  SettingMaxListItemOptions &
+  SettingTriggerListItemOptions;
+
 export class WorkshopCraftListItem<
-  TOptions extends SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsLimited &
-    SettingListItemOptionsMax &
-    SettingListItemOptionsTrigger = SettingListItemOptions<UiComponent> &
-    SettingListItemOptionsLimited &
-    SettingListItemOptionsMax &
-    SettingListItemOptionsTrigger,
+  TOptions extends WorkshopCraftListItemOptions = WorkshopCraftListItemOptions,
 > extends SettingListItem<CraftSettingsItem> {
   readonly limitedButton: LimitedButton;
   readonly maxButton: MaxButton;

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -31,7 +31,7 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
     setting: CraftSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: WorkshopCraftListItemOptions,
+    options: WorkshopCraftListItemOptions,
   ) {
     super(parent, setting, label, options);
 
@@ -44,14 +44,14 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
-      onClick: options?.onSetMax ? () => options.onSetMax?.call(this) : undefined,
+      onClick: () => options.onSetMax.call(this),
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
 
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
+      onClick: () => options.onSetTrigger?.call(this),
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
     this.addChildrenHead([

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -17,7 +17,8 @@ import { TriggerButton } from "./buttons/TriggerButton.js";
 export type WorkshopCraftListItemOptions = SettingListItemOptions &
   SettingLimitedListItemOptions &
   SettingMaxListItemOptions &
-  SettingTriggerListItemOptions;
+  SettingTriggerListItemOptions &
+  ThisType<WorkshopCraftListItem>;
 
 export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
   declare readonly _options: WorkshopCraftListItemOptions;

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -1,5 +1,4 @@
 import type { SupportedLocale } from "../../Engine.js";
-import type { KittenScientists } from "../../KittenScientists.js";
 import type { SettingOptions } from "../../settings/Settings.js";
 import type { CraftSettingsItem } from "../../settings/WorkshopSettings.js";
 import stylesButton from "./Button.module.css";
@@ -10,6 +9,7 @@ import type { SettingLimitedListItemOptions } from "./SettingLimitedListItem.js"
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import type { SettingMaxListItemOptions } from "./SettingMaxListItem.js";
 import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
+import type { UiComponent } from "./UiComponent.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
@@ -21,26 +21,26 @@ export type WorkshopCraftListItemOptions = SettingListItemOptions &
   ThisType<WorkshopCraftListItem>;
 
 export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
-  declare readonly _options: WorkshopCraftListItemOptions;
+  declare readonly options: WorkshopCraftListItemOptions;
   readonly limitedButton: LimitedButton;
   readonly maxButton: MaxButton;
   readonly triggerButton: TriggerButton;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: CraftSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     label: string,
     options?: WorkshopCraftListItemOptions,
   ) {
-    super(host, setting, label, options);
+    super(parent, setting, label, options);
 
-    this.limitedButton = new LimitedButton(host, setting, {
+    this.limitedButton = new LimitedButton(parent, setting, {
       ...options,
       classes: [stylesListItem.headAction],
     });
 
-    this.maxButton = new MaxButton(host, setting, {
+    this.maxButton = new MaxButton(parent, setting, {
       alignment: "right",
       border: false,
       classes: [stylesButton.headAction],
@@ -48,7 +48,7 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
       onRefresh: options?.onRefreshMax ? () => options.onRefreshMax?.call(this) : undefined,
     });
 
-    this.triggerButton = new TriggerButton(host, setting, locale, {
+    this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
       onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
@@ -57,7 +57,7 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
         : undefined,
     });
     this.head.addChildren([
-      new Container(host, { classes: [stylesLabelListItem.fillSpace] }),
+      new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.limitedButton,
       this.maxButton,
       this.triggerButton,

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -51,8 +51,12 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
     this.triggerButton = new TriggerButton(parent, setting, locale, {
       border: false,
       classes: [stylesButton.lastHeadAction],
-      onClick: () => options.onSetTrigger?.call(this),
+      onClick: async () => {
+        await options.onSetTrigger.call(this);
+        this.requestRefresh();
+      },
       onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
+      renderLabel: options?.renderLabelTrigger ?? true,
     });
     this.addChildrenHead([
       new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -10,19 +10,17 @@ import type { SettingLimitedListItemOptions } from "./SettingLimitedListItem.js"
 import { SettingListItem, type SettingListItemOptions } from "./SettingListItem.js";
 import type { SettingMaxListItemOptions } from "./SettingMaxListItem.js";
 import type { SettingTriggerListItemOptions } from "./SettingTriggerListItem.js";
-import type { UiComponent } from "./UiComponent.js";
 import { LimitedButton } from "./buttons/LimitedButton.js";
 import { MaxButton } from "./buttons/MaxButton.js";
 import { TriggerButton } from "./buttons/TriggerButton.js";
 
-export type WorkshopCraftListItemOptions = SettingListItemOptions<UiComponent> &
+export type WorkshopCraftListItemOptions = SettingListItemOptions &
   SettingLimitedListItemOptions &
   SettingMaxListItemOptions &
   SettingTriggerListItemOptions;
 
-export class WorkshopCraftListItem<
-  TOptions extends WorkshopCraftListItemOptions = WorkshopCraftListItemOptions,
-> extends SettingListItem<CraftSettingsItem> {
+export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
+  declare readonly _options: WorkshopCraftListItemOptions;
   readonly limitedButton: LimitedButton;
   readonly maxButton: MaxButton;
   readonly triggerButton: TriggerButton;
@@ -32,7 +30,7 @@ export class WorkshopCraftListItem<
     setting: CraftSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     label: string,
-    options?: Partial<TOptions>,
+    options?: WorkshopCraftListItemOptions,
   ) {
     super(host, setting, label, options);
 

--- a/source/ui/components/WorkshopCraftListItem.ts
+++ b/source/ui/components/WorkshopCraftListItem.ts
@@ -52,11 +52,9 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
       border: false,
       classes: [stylesButton.lastHeadAction],
       onClick: options?.onSetTrigger ? () => options.onSetTrigger?.call(this) : undefined,
-      onRefreshTitle: options?.onRefreshTrigger
-        ? () => options.onRefreshTrigger?.call(this)
-        : undefined,
+      onRefresh: options?.onRefreshTrigger ? () => options.onRefreshTrigger?.call(this) : undefined,
     });
-    this.head.addChildren([
+    this.addChildrenHead([
       new Container(parent, { classes: [stylesLabelListItem.fillSpace] }),
       this.limitedButton,
       this.maxButton,
@@ -64,11 +62,7 @@ export class WorkshopCraftListItem extends SettingListItem<CraftSettingsItem> {
     ]);
   }
 
-  refreshUi() {
-    super.refreshUi();
-
-    this.limitedButton.refreshUi();
-    this.maxButton.refreshUi();
-    this.triggerButton.refreshUi();
+  toString(): string {
+    return `[${WorkshopCraftListItem.name}#${this.componentId}]`;
   }
 }

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -1,32 +1,32 @@
 import type { SupportedLocale } from "../../../Engine.js";
-import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingBuy, SettingOptions } from "../../../settings/Settings.js";
 import { Dialog } from "../Dialog.js";
 import { TextButton, type TextButtonOptions } from "../TextButton.js";
+import type { UiComponent } from "../UiComponent.js";
 import styles from "./BuyButton.module.css";
 
 export type BuyButtonOptions = ThisType<BuyButton> & TextButtonOptions;
 
 export class BuyButton extends TextButton {
-  declare readonly _options: BuyButtonOptions;
+  declare readonly options: BuyButtonOptions;
   readonly setting: SettingBuy;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingBuy,
     locale: SettingOptions<SupportedLocale>,
     options?: BuyButtonOptions,
   ) {
-    super(host, undefined, {
+    super(parent, undefined, {
       onClick: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("blackcoin.buy.prompt"),
-          host.engine.i18n("blackcoin.buy.promptTitle", [
-            host.renderAbsolute(setting.buy, locale.selected),
+          parent,
+          parent.host.engine.i18n("blackcoin.buy.prompt"),
+          parent.host.engine.i18n("blackcoin.buy.promptTitle", [
+            parent.host.renderAbsolute(setting.buy, locale.selected),
           ]),
-          host.renderAbsolute(setting.buy),
-          host.engine.i18n("blackcoin.buy.promptExplainer"),
+          parent.host.renderAbsolute(setting.buy),
+          parent.host.engine.i18n("blackcoin.buy.promptExplainer"),
         );
 
         if (value === undefined) {
@@ -38,7 +38,7 @@ export class BuyButton extends TextButton {
           return;
         }
 
-        setting.buy = host.parseAbsolute(value) ?? setting.buy;
+        setting.buy = parent.host.parseAbsolute(value) ?? setting.buy;
       },
     });
 
@@ -52,10 +52,10 @@ export class BuyButton extends TextButton {
 
     this.element.prop(
       "title",
-      this._host.engine.i18n("blackcoin.buy.title", [this._host.renderAbsolute(this.setting.buy)]),
+      this.host.engine.i18n("blackcoin.buy.title", [this.host.renderAbsolute(this.setting.buy)]),
     );
     this.element.text(
-      this._host.engine.i18n("blackcoin.buy", [this._host.renderAbsolute(this.setting.buy)]),
+      this.host.engine.i18n("blackcoin.buy", [this.host.renderAbsolute(this.setting.buy)]),
     );
   }
 }

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -3,7 +3,7 @@ import type { SupportedLocale } from "../../../Engine.js";
 import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingBuy, SettingOptions } from "../../../settings/Settings.js";
 import { Dialog } from "../Dialog.js";
-import { TextButton } from "../TextButton.js";
+import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./BuyButton.module.css";
 
 export class BuyButton extends TextButton {
@@ -13,7 +13,7 @@ export class BuyButton extends TextButton {
     host: KittenScientists,
     setting: SettingBuy,
     locale: SettingOptions<SupportedLocale>,
-    handler: { onClick?: () => void } = {},
+    options?: TextButtonOptions,
   ) {
     super(host, undefined, {
       onClick: () => {
@@ -40,10 +40,7 @@ export class BuyButton extends TextButton {
           })
           .then(() => {
             this.refreshUi();
-
-            if (handler.onClick) {
-              handler.onClick();
-            }
+            options?.onClick?.();
           })
           .catch(redirectErrorsToConsole(console));
       },

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -6,7 +6,7 @@ import { Dialog } from "../Dialog.js";
 import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./BuyButton.module.css";
 
-export type BuyButtonOptions = TextButtonOptions & ThisType<BuyButton>;
+export type BuyButtonOptions = ThisType<BuyButton> & TextButtonOptions;
 
 export class BuyButton extends TextButton {
   declare readonly _options: BuyButtonOptions;

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -39,9 +39,6 @@ export class BuyButton extends TextButton {
         }
 
         setting.buy = host.parseAbsolute(value) ?? setting.buy;
-
-        this.refreshUi();
-        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -51,7 +51,7 @@ export class BuyButton extends TextButton {
     return `[${BuyButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     super.refreshUi();
 
     this.element.prop(

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -6,15 +6,17 @@ import { Dialog } from "../Dialog.js";
 import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./BuyButton.module.css";
 
+export type BuyButtonOptions = TextButtonOptions & ThisType<BuyButton>;
+
 export class BuyButton extends TextButton {
-  declare readonly _options: TextButtonOptions;
+  declare readonly _options: BuyButtonOptions;
   readonly setting: SettingBuy;
 
   constructor(
     host: KittenScientists,
     setting: SettingBuy,
     locale: SettingOptions<SupportedLocale>,
-    options?: TextButtonOptions,
+    options?: BuyButtonOptions,
   ) {
     super(host, undefined, {
       onClick: () => {

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -47,6 +47,10 @@ export class BuyButton extends TextButton {
     this.setting = setting;
   }
 
+  toString(): string {
+    return `[${BuyButton.name}#${this.componentId}]`;
+  }
+
   refreshUi() {
     super.refreshUi();
 

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../../../Engine.js";
 import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingBuy, SettingOptions } from "../../../settings/Settings.js";
@@ -19,8 +18,8 @@ export class BuyButton extends TextButton {
     options?: BuyButtonOptions,
   ) {
     super(host, undefined, {
-      onClick: () => {
-        Dialog.prompt(
+      onClick: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("blackcoin.buy.prompt"),
           host.engine.i18n("blackcoin.buy.promptTitle", [
@@ -28,24 +27,21 @@ export class BuyButton extends TextButton {
           ]),
           host.renderAbsolute(setting.buy),
           host.engine.i18n("blackcoin.buy.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              setting.buy = -1;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            setting.buy = host.parseAbsolute(value) ?? setting.buy;
-          })
-          .then(() => {
-            this.refreshUi();
-            options?.onClick?.();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          setting.buy = -1;
+          return;
+        }
+
+        setting.buy = host.parseAbsolute(value) ?? setting.buy;
+
+        this.refreshUi();
+        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons-text/BuyButton.ts
+++ b/source/ui/components/buttons-text/BuyButton.ts
@@ -7,6 +7,7 @@ import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./BuyButton.module.css";
 
 export class BuyButton extends TextButton {
+  declare readonly _options: TextButtonOptions;
   readonly setting: SettingBuy;
 
   constructor(

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../../../Engine.js";
 import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingOptions, SettingSell } from "../../../settings/Settings.js";
@@ -19,8 +18,8 @@ export class SellButton extends TextButton {
     options?: SellButtonOptions,
   ) {
     super(host, undefined, {
-      onClick: () => {
-        Dialog.prompt(
+      onClick: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("blackcoin.sell.prompt"),
           host.engine.i18n("blackcoin.sell.promptTitle", [
@@ -28,24 +27,21 @@ export class SellButton extends TextButton {
           ]),
           host.renderAbsolute(setting.sell),
           host.engine.i18n("blackcoin.sell.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              setting.sell = -1;
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            setting.sell = host.parseAbsolute(value) ?? setting.sell;
-          })
-          .then(() => {
-            this.refreshUi();
-            options?.onClick?.();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          setting.sell = -1;
+          return;
+        }
+
+        setting.sell = host.parseAbsolute(value) ?? setting.sell;
+
+        this.refreshUi();
+        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -7,6 +7,7 @@ import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./SellButton.module.css";
 
 export class SellButton extends TextButton {
+  declare readonly _options: TextButtonOptions;
   readonly setting: SettingSell;
 
   constructor(

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -39,9 +39,6 @@ export class SellButton extends TextButton {
         }
 
         setting.sell = host.parseAbsolute(value) ?? setting.sell;
-
-        this.refreshUi();
-        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -51,7 +51,7 @@ export class SellButton extends TextButton {
     return `[${SellButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     super.refreshUi();
 
     this.element.prop(

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -6,7 +6,7 @@ import { Dialog } from "../Dialog.js";
 import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./SellButton.module.css";
 
-export type SellButtonOptions = TextButtonOptions & ThisType<SellButton>;
+export type SellButtonOptions = ThisType<SellButton> & TextButtonOptions;
 
 export class SellButton extends TextButton {
   declare readonly _options: SellButtonOptions;

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -1,32 +1,32 @@
 import type { SupportedLocale } from "../../../Engine.js";
-import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingOptions, SettingSell } from "../../../settings/Settings.js";
 import { Dialog } from "../Dialog.js";
 import { TextButton, type TextButtonOptions } from "../TextButton.js";
+import type { UiComponent } from "../UiComponent.js";
 import styles from "./SellButton.module.css";
 
 export type SellButtonOptions = ThisType<SellButton> & TextButtonOptions;
 
 export class SellButton extends TextButton {
-  declare readonly _options: SellButtonOptions;
+  declare readonly options: SellButtonOptions;
   readonly setting: SettingSell;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingSell,
     locale: SettingOptions<SupportedLocale>,
     options?: SellButtonOptions,
   ) {
-    super(host, undefined, {
+    super(parent, undefined, {
       onClick: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("blackcoin.sell.prompt"),
-          host.engine.i18n("blackcoin.sell.promptTitle", [
-            host.renderAbsolute(setting.sell, locale.selected),
+          parent,
+          parent.host.engine.i18n("blackcoin.sell.prompt"),
+          parent.host.engine.i18n("blackcoin.sell.promptTitle", [
+            parent.host.renderAbsolute(setting.sell, locale.selected),
           ]),
-          host.renderAbsolute(setting.sell),
-          host.engine.i18n("blackcoin.sell.promptExplainer"),
+          parent.host.renderAbsolute(setting.sell),
+          parent.host.engine.i18n("blackcoin.sell.promptExplainer"),
         );
 
         if (value === undefined) {
@@ -38,7 +38,7 @@ export class SellButton extends TextButton {
           return;
         }
 
-        setting.sell = host.parseAbsolute(value) ?? setting.sell;
+        setting.sell = parent.host.parseAbsolute(value) ?? setting.sell;
       },
     });
 
@@ -52,12 +52,10 @@ export class SellButton extends TextButton {
 
     this.element.prop(
       "title",
-      this._host.engine.i18n("blackcoin.sell.title", [
-        this._host.renderAbsolute(this.setting.sell),
-      ]),
+      this.host.engine.i18n("blackcoin.sell.title", [this.host.renderAbsolute(this.setting.sell)]),
     );
     this.element.text(
-      this._host.engine.i18n("blackcoin.sell", [this._host.renderAbsolute(this.setting.sell)]),
+      this.host.engine.i18n("blackcoin.sell", [this.host.renderAbsolute(this.setting.sell)]),
     );
   }
 }

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -3,7 +3,7 @@ import type { SupportedLocale } from "../../../Engine.js";
 import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingOptions, SettingSell } from "../../../settings/Settings.js";
 import { Dialog } from "../Dialog.js";
-import { TextButton } from "../TextButton.js";
+import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./SellButton.module.css";
 
 export class SellButton extends TextButton {
@@ -13,7 +13,7 @@ export class SellButton extends TextButton {
     host: KittenScientists,
     setting: SettingSell,
     locale: SettingOptions<SupportedLocale>,
-    handler: { onClick?: () => void } = {},
+    options?: TextButtonOptions,
   ) {
     super(host, undefined, {
       onClick: () => {
@@ -40,10 +40,7 @@ export class SellButton extends TextButton {
           })
           .then(() => {
             this.refreshUi();
-
-            if (handler.onClick) {
-              handler.onClick();
-            }
+            options?.onClick?.();
           })
           .catch(redirectErrorsToConsole(console));
       },

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -47,6 +47,10 @@ export class SellButton extends TextButton {
     this.setting = setting;
   }
 
+  toString(): string {
+    return `[${SellButton.name}#${this.componentId}]`;
+  }
+
   refreshUi() {
     super.refreshUi();
 

--- a/source/ui/components/buttons-text/SellButton.ts
+++ b/source/ui/components/buttons-text/SellButton.ts
@@ -6,15 +6,17 @@ import { Dialog } from "../Dialog.js";
 import { TextButton, type TextButtonOptions } from "../TextButton.js";
 import styles from "./SellButton.module.css";
 
+export type SellButtonOptions = TextButtonOptions & ThisType<SellButton>;
+
 export class SellButton extends TextButton {
-  declare readonly _options: TextButtonOptions;
+  declare readonly _options: SellButtonOptions;
   readonly setting: SettingSell;
 
   constructor(
     host: KittenScientists,
     setting: SettingSell,
     locale: SettingOptions<SupportedLocale>,
-    options?: TextButtonOptions,
+    options?: SellButtonOptions,
   ) {
     super(host, undefined, {
       onClick: () => {

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -57,7 +57,7 @@ export class ConsumeButton extends Button {
     return `[${ConsumeButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     super.refreshUi();
 
     const consumeValue = this.host.renderPercentage(

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -1,38 +1,38 @@
 import type { SupportedLocale } from "../../../Engine.js";
-import type { KittenScientists } from "../../../KittenScientists.js";
 import { Icons } from "../../../images/Icons.js";
 import type { ResourcesSettingsItem } from "../../../settings/ResourcesSettings.js";
 import type { SettingOptions } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
+import type { UiComponent } from "../UiComponent.js";
 
 export type ConsumeButtonOptions = ThisType<ConsumeButton> & ButtonOptions;
 
 export class ConsumeButton extends Button {
-  declare readonly _options: ConsumeButtonOptions;
+  declare readonly options: ConsumeButtonOptions;
   readonly setting: ResourcesSettingsItem;
   readonly resourceName: string;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
     options?: ConsumeButtonOptions,
   ) {
-    super(host, "", Icons.DataUsage, {
+    super(parent, "", Icons.DataUsage, {
       ...options,
       onClick: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("resources.consume.prompt"),
-          host.engine.i18n("resources.consume.promptTitle", [
+          parent,
+          parent.host.engine.i18n("resources.consume.prompt"),
+          parent.host.engine.i18n("resources.consume.promptTitle", [
             resourceName,
-            host.renderPercentage(setting.consume, locale.selected, true),
+            parent.host.renderPercentage(setting.consume, locale.selected, true),
           ]),
-          host.renderPercentage(setting.consume),
-          host.engine.i18n("resources.consume.promptExplainer"),
+          parent.host.renderPercentage(setting.consume),
+          parent.host.engine.i18n("resources.consume.promptExplainer"),
         );
 
         if (value === undefined) {
@@ -43,7 +43,7 @@ export class ConsumeButton extends Button {
           return;
         }
 
-        setting.consume = host.parsePercentage(value);
+        setting.consume = parent.host.parsePercentage(value);
       },
     });
 
@@ -56,15 +56,15 @@ export class ConsumeButton extends Button {
   refreshUi() {
     super.refreshUi();
 
-    const consumeValue = this._host.renderPercentage(
+    const consumeValue = this.host.renderPercentage(
       this.setting.consume,
-      this._host.engine.settings.locale.selected,
+      this.host.engine.settings.locale.selected,
       true,
     );
     const title =
       this.setting.consume === 0
-        ? this._host.engine.i18n("resources.consume.titleZero", [this.resourceName])
-        : this._host.engine.i18n("resources.consume.title", [consumeValue, this.resourceName]);
+        ? this.host.engine.i18n("resources.consume.titleZero", [this.resourceName])
+        : this.host.engine.i18n("resources.consume.title", [consumeValue, this.resourceName]);
     this.updateTitle(title);
   }
 }

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -9,6 +9,7 @@ import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
 
 export class ConsumeButton extends Button {
+  declare readonly _options: ButtonOptions;
   readonly setting: ResourcesSettingsItem;
   readonly resourceName: string;
 
@@ -17,7 +18,7 @@ export class ConsumeButton extends Button {
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
-    options?: Partial<ButtonOptions>,
+    options?: ButtonOptions,
   ) {
     super(host, "", Icons.DataUsage, {
       ...options,
@@ -45,10 +46,7 @@ export class ConsumeButton extends Button {
           })
           .then(() => {
             this.refreshUi();
-
-            if (options?.onClick) {
-              options.onClick(this);
-            }
+            options?.onClick?.();
           })
           .catch(redirectErrorsToConsole(console));
       },

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -19,7 +19,7 @@ export class ConsumeButton extends Button {
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
-    options?: ConsumeButtonOptions,
+    options: Omit<ConsumeButtonOptions, "onClick">,
   ) {
     super(parent, "", Icons.DataUsage, {
       ...options,

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -8,8 +8,10 @@ import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
 
+export type ConsumeButtonOptions = ButtonOptions & ThisType<ConsumeButton>;
+
 export class ConsumeButton extends Button {
-  declare readonly _options: ButtonOptions;
+  declare readonly _options: ConsumeButtonOptions;
   readonly setting: ResourcesSettingsItem;
   readonly resourceName: string;
 
@@ -18,7 +20,7 @@ export class ConsumeButton extends Button {
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
-    options?: ButtonOptions,
+    options?: ConsumeButtonOptions,
   ) {
     super(host, "", Icons.DataUsage, {
       ...options,

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -44,9 +44,6 @@ export class ConsumeButton extends Button {
         }
 
         setting.consume = host.parsePercentage(value);
-
-        this.refreshUi();
-        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../../../Engine.js";
 import type { KittenScientists } from "../../../KittenScientists.js";
 import { Icons } from "../../../images/Icons.js";
@@ -24,8 +23,8 @@ export class ConsumeButton extends Button {
   ) {
     super(host, "", Icons.DataUsage, {
       ...options,
-      onClick: () => {
-        Dialog.prompt(
+      onClick: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("resources.consume.prompt"),
           host.engine.i18n("resources.consume.promptTitle", [
@@ -34,23 +33,20 @@ export class ConsumeButton extends Button {
           ]),
           host.renderPercentage(setting.consume),
           host.engine.i18n("resources.consume.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
 
-            if (value === "" || value.startsWith("-")) {
-              return;
-            }
+        if (value === undefined) {
+          return;
+        }
 
-            setting.consume = host.parsePercentage(value);
-          })
-          .then(() => {
-            this.refreshUi();
-            options?.onClick?.();
-          })
-          .catch(redirectErrorsToConsole(console));
+        if (value === "" || value.startsWith("-")) {
+          return;
+        }
+
+        setting.consume = host.parsePercentage(value);
+
+        this.refreshUi();
+        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -53,6 +53,10 @@ export class ConsumeButton extends Button {
     this.setting = setting;
   }
 
+  toString(): string {
+    return `[${ConsumeButton.name}#${this.componentId}]`;
+  }
+
   refreshUi() {
     super.refreshUi();
 

--- a/source/ui/components/buttons/ConsumeButton.ts
+++ b/source/ui/components/buttons/ConsumeButton.ts
@@ -8,7 +8,7 @@ import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
 
-export type ConsumeButtonOptions = ButtonOptions & ThisType<ConsumeButton>;
+export type ConsumeButtonOptions = ThisType<ConsumeButton> & ButtonOptions;
 
 export class ConsumeButton extends Button {
   declare readonly _options: ConsumeButtonOptions;

--- a/source/ui/components/buttons/ExpandoButton.ts
+++ b/source/ui/components/buttons/ExpandoButton.ts
@@ -4,7 +4,7 @@ import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
 import styles from "./ExpandoButton.module.css";
 
-export type ExpandoButtonOptions = UiComponentOptions & ThisType<ExpandoButton>;
+export type ExpandoButtonOptions = ThisType<ExpandoButton> & UiComponentOptions;
 
 export class ExpandoButton extends UiComponent {
   declare readonly _options: ExpandoButtonOptions;

--- a/source/ui/components/buttons/ExpandoButton.ts
+++ b/source/ui/components/buttons/ExpandoButton.ts
@@ -4,7 +4,10 @@ import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
 import styles from "./ExpandoButton.module.css";
 
+export type ExpandoButtonOptions = UiComponentOptions & ThisType<ExpandoButton>;
+
 export class ExpandoButton extends UiComponent {
+  declare readonly _options: ExpandoButtonOptions;
   readonly element: JQuery;
   ineffective: boolean;
 
@@ -15,7 +18,7 @@ export class ExpandoButton extends UiComponent {
    * @param host A reference to the host.
    * @param options Options for this expando.
    */
-  constructor(host: KittenScientists, options?: UiComponentOptions) {
+  constructor(host: KittenScientists, options?: ExpandoButtonOptions) {
     super(host, { ...options });
 
     const element = $("<div/>", {

--- a/source/ui/components/buttons/ExpandoButton.ts
+++ b/source/ui/components/buttons/ExpandoButton.ts
@@ -1,4 +1,3 @@
-import type { KittenScientists } from "../../../KittenScientists.js";
 import { Icons } from "../../../images/Icons.js";
 import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
@@ -7,7 +6,7 @@ import styles from "./ExpandoButton.module.css";
 export type ExpandoButtonOptions = ThisType<ExpandoButton> & UiComponentOptions;
 
 export class ExpandoButton extends UiComponent {
-  declare readonly _options: ExpandoButtonOptions;
+  declare readonly options: ExpandoButtonOptions;
   readonly element: JQuery;
   ineffective: boolean;
 
@@ -18,15 +17,15 @@ export class ExpandoButton extends UiComponent {
    * @param host A reference to the host.
    * @param options Options for this expando.
    */
-  constructor(host: KittenScientists, options?: ExpandoButtonOptions) {
-    super(host, { ...options });
+  constructor(parent: UiComponent, options?: ExpandoButtonOptions) {
+    super(parent, { ...options });
 
     const element = $("<div/>", {
       html: `
       <svg style="width: 18px; height: 18px;" viewBox="0 -960 960 960" fill="currentColor" class="${styles.down}"><path d="${Icons.ExpandCircleDown}"/></svg>
       <svg style="width: 18px; height: 18px;" viewBox="0 -960 960 960" fill="currentColor" class="${styles.up}"><path d="${Icons.ExpandCircleUp}"/></svg>
       `,
-      title: host.engine.i18n("ui.itemsShow"),
+      title: parent.host.engine.i18n("ui.itemsShow"),
     })
       .addClass(stylesButton.iconButton)
       .addClass(styles.expandoButton);
@@ -38,11 +37,11 @@ export class ExpandoButton extends UiComponent {
 
   setCollapsed() {
     this.element.removeClass(styles.expanded);
-    this.element.prop("title", this._host.engine.i18n("ui.itemsShow"));
+    this.element.prop("title", this.host.engine.i18n("ui.itemsShow"));
   }
   setExpanded() {
     this.element.addClass(styles.expanded);
-    this.element.prop("title", this._host.engine.i18n("ui.itemsHide"));
+    this.element.prop("title", this.host.engine.i18n("ui.itemsHide"));
   }
 
   override refreshUi(): void {

--- a/source/ui/components/buttons/ExpandoButton.ts
+++ b/source/ui/components/buttons/ExpandoButton.ts
@@ -15,8 +15,8 @@ export class ExpandoButton extends UiComponent {
    * @param host A reference to the host.
    * @param options Options for this expando.
    */
-  constructor(host: KittenScientists, options?: Partial<UiComponentOptions>) {
-    super(host, options);
+  constructor(host: KittenScientists, options?: UiComponentOptions) {
+    super(host, { ...options });
 
     const element = $("<div/>", {
       html: `

--- a/source/ui/components/buttons/ExpandoButton.ts
+++ b/source/ui/components/buttons/ExpandoButton.ts
@@ -3,7 +3,8 @@ import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
 import styles from "./ExpandoButton.module.css";
 
-export type ExpandoButtonOptions = ThisType<ExpandoButton> & UiComponentOptions;
+export type ExpandoButtonOptions = ThisType<ExpandoButton> &
+  UiComponentOptions & { readonly onClick?: (event?: MouseEvent) => void | Promise<void> };
 
 export class ExpandoButton extends UiComponent {
   declare readonly options: ExpandoButtonOptions;
@@ -20,7 +21,7 @@ export class ExpandoButton extends UiComponent {
   constructor(parent: UiComponent, options?: ExpandoButtonOptions) {
     super(parent, { ...options });
 
-    const element = $("<div/>", {
+    this.element = $("<div/>", {
       html: `
       <svg style="width: 18px; height: 18px;" viewBox="0 -960 960 960" fill="currentColor" class="${styles.down}"><path d="${Icons.ExpandCircleDown}"/></svg>
       <svg style="width: 18px; height: 18px;" viewBox="0 -960 960 960" fill="currentColor" class="${styles.up}"><path d="${Icons.ExpandCircleUp}"/></svg>
@@ -30,9 +31,13 @@ export class ExpandoButton extends UiComponent {
       .addClass(stylesButton.iconButton)
       .addClass(styles.expandoButton);
 
-    this.element = element;
-    this.addChildren(options?.children);
+    this.element.on("click", () => options?.onClick?.call(this));
+
     this.ineffective = false;
+  }
+
+  toString(): string {
+    return `[${ExpandoButton.name}#${this.componentId}]`;
   }
 
   setCollapsed() {
@@ -44,9 +49,7 @@ export class ExpandoButton extends UiComponent {
     this.element.prop("title", this.host.engine.i18n("ui.itemsHide"));
   }
 
-  override refreshUi(): void {
-    super.refreshUi();
-
+  refreshUi(): void {
     if (this.ineffective) {
       this.element.addClass(stylesButton.ineffective);
     } else {

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -7,7 +7,7 @@ import stylesButton from "../Button.module.css";
 export type LimitedButtonOptions = ButtonOptions & {
   readonly onLimitedCheck?: () => void;
   readonly onLimitedUnCheck?: () => void;
-};
+} & ThisType<LimitedButton>;
 
 export class LimitedButton extends Button {
   declare readonly _options: LimitedButtonOptions;

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -32,7 +32,7 @@ export class LimitedButton extends Button {
           options?.onLimitedUnCheck?.call(this);
         }
 
-        this.refreshUi();
+        this.requestRefresh();
       },
     });
 
@@ -47,7 +47,7 @@ export class LimitedButton extends Button {
     return `[${LimitedButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     super.refreshUi();
 
     this.updateTitle(

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -1,11 +1,10 @@
 import type { KittenScientists } from "../../../KittenScientists.js";
 import { Icons } from "../../../images/Icons.js";
 import type { SettingLimited } from "../../../settings/Settings.js";
-import { Button } from "../Button.js";
+import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
-import type { UiComponentOptions } from "../UiComponent.js";
 
-export type LimitedButtonOptions = UiComponentOptions & {
+export type LimitedButtonOptions = ButtonOptions & {
   readonly onLimitedCheck: () => void;
   readonly onLimitedUnCheck: () => void;
 };

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -10,6 +10,7 @@ export type LimitedButtonOptions = ButtonOptions & {
 };
 
 export class LimitedButton extends Button {
+  declare readonly _options: LimitedButtonOptions;
   readonly setting: SettingLimited;
 
   constructor(host: KittenScientists, setting: SettingLimited, options?: LimitedButtonOptions) {

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -22,9 +22,9 @@ export class LimitedButton extends Button {
       this.setting.limited = !this.setting.limited;
 
       if (this.setting.limited) {
-        options?.onLimitedCheck?.();
+        options?.onLimitedCheck?.call(this);
       } else {
-        options?.onLimitedUnCheck?.();
+        options?.onLimitedUnCheck?.call(this);
       }
 
       this.refreshUi();
@@ -33,6 +33,10 @@ export class LimitedButton extends Button {
     for (const className of options?.classes ?? []) {
       this.element.addClass(className);
     }
+  }
+
+  toString(): string {
+    return `[${LimitedButton.name}#${this.componentId}]`;
   }
 
   refreshUi() {

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -4,10 +4,11 @@ import type { SettingLimited } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 
-export type LimitedButtonOptions = ButtonOptions & {
-  readonly onLimitedCheck?: () => void;
-  readonly onLimitedUnCheck?: () => void;
-} & ThisType<LimitedButton>;
+export type LimitedButtonOptions = ThisType<LimitedButton> &
+  ButtonOptions & {
+    readonly onLimitedCheck?: () => void;
+    readonly onLimitedUnCheck?: () => void;
+  };
 
 export class LimitedButton extends Button {
   declare readonly _options: LimitedButtonOptions;

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -5,18 +5,14 @@ import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 
 export type LimitedButtonOptions = ButtonOptions & {
-  readonly onLimitedCheck: () => void;
-  readonly onLimitedUnCheck: () => void;
+  readonly onLimitedCheck?: () => void;
+  readonly onLimitedUnCheck?: () => void;
 };
 
 export class LimitedButton extends Button {
   readonly setting: SettingLimited;
 
-  constructor(
-    host: KittenScientists,
-    setting: SettingLimited,
-    options?: Partial<LimitedButtonOptions>,
-  ) {
+  constructor(host: KittenScientists, setting: SettingLimited, options?: LimitedButtonOptions) {
     super(host, "", Icons.Eco, { ...options, border: false, classes: [] });
 
     this.setting = setting;

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -1,8 +1,8 @@
-import type { KittenScientists } from "../../../KittenScientists.js";
 import { Icons } from "../../../images/Icons.js";
 import type { SettingLimited } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
+import type { UiComponent } from "../UiComponent.js";
 
 export type LimitedButtonOptions = ThisType<LimitedButton> &
   ButtonOptions & {
@@ -11,11 +11,11 @@ export type LimitedButtonOptions = ThisType<LimitedButton> &
   };
 
 export class LimitedButton extends Button {
-  declare readonly _options: LimitedButtonOptions;
+  declare readonly options: LimitedButtonOptions;
   readonly setting: SettingLimited;
 
-  constructor(host: KittenScientists, setting: SettingLimited, options?: LimitedButtonOptions) {
-    super(host, "", Icons.Eco, { ...options, border: false, classes: [] });
+  constructor(parent: UiComponent, setting: SettingLimited, options?: LimitedButtonOptions) {
+    super(parent, "", Icons.Eco, { ...options, border: false, classes: [] });
 
     this.setting = setting;
     this.element.on("click", () => {
@@ -39,7 +39,7 @@ export class LimitedButton extends Button {
     super.refreshUi();
 
     this.updateTitle(
-      this._host.engine.i18n(this.setting.limited ? "ui.limited.on" : "ui.limited.off"),
+      this.host.engine.i18n(this.setting.limited ? "ui.limited.on" : "ui.limited.off"),
     );
     if (this.setting.limited && !this.inactive) {
       this.element.removeClass(stylesButton.inactive);

--- a/source/ui/components/buttons/LimitedButton.ts
+++ b/source/ui/components/buttons/LimitedButton.ts
@@ -14,21 +14,29 @@ export class LimitedButton extends Button {
   declare readonly options: LimitedButtonOptions;
   readonly setting: SettingLimited;
 
-  constructor(parent: UiComponent, setting: SettingLimited, options?: LimitedButtonOptions) {
-    super(parent, "", Icons.Eco, { ...options, border: false, classes: [] });
+  constructor(
+    parent: UiComponent,
+    setting: SettingLimited,
+    options: Omit<LimitedButtonOptions, "onClick">,
+  ) {
+    super(parent, "", Icons.Eco, {
+      ...options,
+      border: false,
+      classes: [],
+      onClick: () => {
+        this.setting.limited = !this.setting.limited;
+
+        if (this.setting.limited) {
+          options?.onLimitedCheck?.call(this);
+        } else {
+          options?.onLimitedUnCheck?.call(this);
+        }
+
+        this.refreshUi();
+      },
+    });
 
     this.setting = setting;
-    this.element.on("click", () => {
-      this.setting.limited = !this.setting.limited;
-
-      if (this.setting.limited) {
-        options?.onLimitedCheck?.call(this);
-      } else {
-        options?.onLimitedUnCheck?.call(this);
-      }
-
-      this.refreshUi();
-    });
 
     for (const className of options?.classes ?? []) {
       this.element.addClass(className);

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -6,13 +6,13 @@ import { Button, type ButtonOptions } from "../Button.js";
 import styles from "./MaxButton.module.css";
 
 export type MaxButtonOptions = ButtonOptions & {
-  readonly onRefresh: (subject: MaxButton) => void;
+  readonly onRefresh?: (subject: MaxButton) => void;
 };
 
 export class MaxButton extends Button {
   readonly setting: SettingMax;
 
-  constructor(host: KittenScientists, setting: SettingMax, options?: Partial<MaxButtonOptions>) {
+  constructor(host: KittenScientists, setting: SettingMax, options?: MaxButtonOptions) {
     super(host, "", null, {
       ...options,
       classes: [styles.maxButton, ...(options?.classes ?? [])],

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -1,18 +1,18 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import { InvalidOperationError } from "@oliversalzburg/js-utils/errors/InvalidOperationError.js";
-import type { KittenScientists } from "../../../KittenScientists.js";
 import type { SettingMax } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
+import type { UiComponent } from "../UiComponent.js";
 import styles from "./MaxButton.module.css";
 
 export type MaxButtonOptions = ThisType<MaxButton> & ButtonOptions;
 
 export class MaxButton extends Button {
-  declare readonly _options: MaxButtonOptions;
+  declare readonly options: MaxButtonOptions;
   readonly setting: SettingMax;
 
-  constructor(host: KittenScientists, setting: SettingMax, options?: MaxButtonOptions) {
-    super(host, "", null, {
+  constructor(parent: UiComponent, setting: SettingMax, options?: MaxButtonOptions) {
+    super(parent, "", null, {
       ...options,
       classes: [styles.maxButton, ...(options?.classes ?? [])],
     });

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -5,9 +5,7 @@ import type { SettingMax } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
 import styles from "./MaxButton.module.css";
 
-export type MaxButtonOptions = ButtonOptions & {
-  readonly onRefresh?: (subject: MaxButton) => void;
-} & ThisType<MaxButton>;
+export type MaxButtonOptions = ThisType<MaxButton> & ButtonOptions;
 
 export class MaxButton extends Button {
   declare readonly _options: MaxButtonOptions;

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -10,6 +10,7 @@ export type MaxButtonOptions = ButtonOptions & {
 };
 
 export class MaxButton extends Button {
+  declare readonly _options: MaxButtonOptions;
   readonly setting: SettingMax;
 
   constructor(host: KittenScientists, setting: SettingMax, options?: MaxButtonOptions) {

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -1,5 +1,3 @@
-import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
-import { InvalidOperationError } from "@oliversalzburg/js-utils/errors/InvalidOperationError.js";
 import type { SettingMax } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
 import type { UiComponent } from "../UiComponent.js";
@@ -16,10 +14,6 @@ export class MaxButton extends Button {
       ...options,
       classes: [styles.maxButton, ...(options?.classes ?? [])],
     });
-
-    if (isNil(options?.onClick)) {
-      throw new InvalidOperationError("Missing click handler on MaxButton.");
-    }
 
     this.setting = setting;
   }

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -7,7 +7,7 @@ import styles from "./MaxButton.module.css";
 
 export type MaxButtonOptions = ButtonOptions & {
   readonly onRefresh?: (subject: MaxButton) => void;
-};
+} & ThisType<MaxButton>;
 
 export class MaxButton extends Button {
   declare readonly _options: MaxButtonOptions;

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -11,7 +11,7 @@ export class MaxButton extends Button {
   declare readonly options: MaxButtonOptions;
   readonly setting: SettingMax;
 
-  constructor(parent: UiComponent, setting: SettingMax, options?: MaxButtonOptions) {
+  constructor(parent: UiComponent, setting: SettingMax, options: MaxButtonOptions) {
     super(parent, "", null, {
       ...options,
       classes: [styles.maxButton, ...(options?.classes ?? [])],

--- a/source/ui/components/buttons/MaxButton.ts
+++ b/source/ui/components/buttons/MaxButton.ts
@@ -23,4 +23,8 @@ export class MaxButton extends Button {
 
     this.setting = setting;
   }
+
+  toString(): string {
+    return `[${MaxButton.name}#${this.componentId}]`;
+  }
 }

--- a/source/ui/components/buttons/PaddingButton.ts
+++ b/source/ui/components/buttons/PaddingButton.ts
@@ -11,8 +11,8 @@ export class PaddingButton extends UiComponent {
    * @param host - A reference to the host.
    * @param options - Options for this button.
    */
-  constructor(host: KittenScientists, options?: Partial<UiComponentOptions>) {
-    super(host, options);
+  constructor(host: KittenScientists, options?: UiComponentOptions) {
+    super(host, { ...options });
 
     const element = $("<div/>", {
       html: `<svg style="width: 18px; height: 18px;"></svg>`,

--- a/source/ui/components/buttons/PaddingButton.ts
+++ b/source/ui/components/buttons/PaddingButton.ts
@@ -21,6 +21,11 @@ export class PaddingButton extends UiComponent {
     }).addClass(stylesButton.iconButton);
 
     this.element = element;
-    this.addChildren(options?.children);
   }
+
+  toString(): string {
+    return `[${PaddingButton.name}#${this.componentId}]`;
+  }
+
+  refreshUi() {}
 }

--- a/source/ui/components/buttons/PaddingButton.ts
+++ b/source/ui/components/buttons/PaddingButton.ts
@@ -1,11 +1,10 @@
-import type { KittenScientists } from "../../../KittenScientists.js";
 import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
 
 export type PaddingButtonOptions = ThisType<PaddingButton> & UiComponentOptions;
 
 export class PaddingButton extends UiComponent {
-  declare readonly _options: PaddingButtonOptions;
+  declare readonly options: PaddingButtonOptions;
   readonly element: JQuery;
 
   /**
@@ -14,8 +13,8 @@ export class PaddingButton extends UiComponent {
    * @param host - A reference to the host.
    * @param options - Options for this button.
    */
-  constructor(host: KittenScientists, options?: PaddingButtonOptions) {
-    super(host, { ...options });
+  constructor(parent: UiComponent, options?: PaddingButtonOptions) {
+    super(parent, { ...options });
 
     const element = $("<div/>", {
       html: `<svg style="width: 18px; height: 18px;"></svg>`,

--- a/source/ui/components/buttons/PaddingButton.ts
+++ b/source/ui/components/buttons/PaddingButton.ts
@@ -2,7 +2,7 @@ import type { KittenScientists } from "../../../KittenScientists.js";
 import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
 
-export type PaddingButtonOptions = UiComponentOptions & ThisType<PaddingButton>;
+export type PaddingButtonOptions = ThisType<PaddingButton> & UiComponentOptions;
 
 export class PaddingButton extends UiComponent {
   declare readonly _options: PaddingButtonOptions;

--- a/source/ui/components/buttons/PaddingButton.ts
+++ b/source/ui/components/buttons/PaddingButton.ts
@@ -2,7 +2,10 @@ import type { KittenScientists } from "../../../KittenScientists.js";
 import stylesButton from "../Button.module.css";
 import { UiComponent, type UiComponentOptions } from "../UiComponent.js";
 
+export type PaddingButtonOptions = UiComponentOptions & ThisType<PaddingButton>;
+
 export class PaddingButton extends UiComponent {
+  declare readonly _options: PaddingButtonOptions;
   readonly element: JQuery;
 
   /**
@@ -11,7 +14,7 @@ export class PaddingButton extends UiComponent {
    * @param host - A reference to the host.
    * @param options - Options for this button.
    */
-  constructor(host: KittenScientists, options?: UiComponentOptions) {
+  constructor(host: KittenScientists, options?: PaddingButtonOptions) {
     super(host, { ...options });
 
     const element = $("<div/>", {

--- a/source/ui/components/buttons/PaddingButton.ts
+++ b/source/ui/components/buttons/PaddingButton.ts
@@ -27,5 +27,5 @@ export class PaddingButton extends UiComponent {
     return `[${PaddingButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {}
+  refreshUi(): void {}
 }

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -1,37 +1,37 @@
 import type { SupportedLocale } from "../../../Engine.js";
-import type { KittenScientists } from "../../../KittenScientists.js";
 import type { ResourcesSettingsItem } from "../../../settings/ResourcesSettings.js";
 import type { SettingOptions } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
+import type { UiComponent } from "../UiComponent.js";
 
 export type StockButtonOptions = ThisType<StockButton> & ButtonOptions;
 
 export class StockButton extends Button {
-  declare readonly _options: StockButtonOptions;
+  declare readonly options: StockButtonOptions;
   readonly setting: ResourcesSettingsItem;
   readonly resourceName: string;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
     options?: StockButtonOptions,
   ) {
-    super(host, "", null, {
+    super(parent, "", null, {
       ...options,
       onClick: async () => {
         const value = await Dialog.prompt(
-          host,
-          host.engine.i18n("resources.stock.prompt"),
-          host.engine.i18n("resources.stock.promptTitle", [
+          parent,
+          parent.host.engine.i18n("resources.stock.prompt"),
+          parent.host.engine.i18n("resources.stock.promptTitle", [
             resourceName,
-            host.renderAbsolute(setting.stock, locale.selected),
+            parent.host.renderAbsolute(setting.stock, locale.selected),
           ]),
-          host.renderAbsolute(setting.stock),
-          host.engine.i18n("resources.stock.promptExplainer"),
+          parent.host.renderAbsolute(setting.stock),
+          parent.host.engine.i18n("resources.stock.promptExplainer"),
         );
         if (value === undefined) {
           return;
@@ -46,7 +46,7 @@ export class StockButton extends Button {
           setting.enabled = false;
         }
 
-        setting.stock = host.parseAbsolute(value) ?? setting.stock;
+        setting.stock = parent.host.parseAbsolute(value) ?? setting.stock;
       },
     });
 
@@ -59,14 +59,14 @@ export class StockButton extends Button {
   refreshUi() {
     super.refreshUi();
 
-    const stockValue = this._host.renderAbsolute(this.setting.stock);
+    const stockValue = this.host.renderAbsolute(this.setting.stock);
     const title =
       this.setting.stock < 0
-        ? this._host.engine.i18n("resources.stock.titleInfinite", [this.resourceName])
+        ? this.host.engine.i18n("resources.stock.titleInfinite", [this.resourceName])
         : this.setting.stock === 0
-          ? this._host.engine.i18n("resources.stock.titleZero", [this.resourceName])
-          : this._host.engine.i18n("resources.stock.title", [
-              this._host.renderAbsolute(this.setting.stock),
+          ? this.host.engine.i18n("resources.stock.titleZero", [this.resourceName])
+          : this.host.engine.i18n("resources.stock.title", [
+              this.host.renderAbsolute(this.setting.stock),
               this.resourceName,
             ]);
     this.updateTitle(title);

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -8,6 +8,7 @@ import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
 
 export class StockButton extends Button {
+  declare readonly _options: ButtonOptions;
   readonly setting: ResourcesSettingsItem;
   readonly resourceName: string;
 
@@ -16,7 +17,7 @@ export class StockButton extends Button {
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
-    options?: Partial<ButtonOptions>,
+    options?: ButtonOptions,
   ) {
     super(host, "", null, {
       ...options,

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -60,7 +60,7 @@ export class StockButton extends Button {
     return `[${StockButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     super.refreshUi();
 
     const stockValue = this.host.renderAbsolute(this.setting.stock);

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -47,9 +47,6 @@ export class StockButton extends Button {
         }
 
         setting.stock = host.parseAbsolute(value) ?? setting.stock;
-
-        this.refreshUi();
-        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -7,7 +7,7 @@ import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
 
-export type StockButtonOptions = ButtonOptions & ThisType<StockButton>;
+export type StockButtonOptions = ThisType<StockButton> & ButtonOptions;
 
 export class StockButton extends Button {
   declare readonly _options: StockButtonOptions;

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -7,8 +7,10 @@ import { Button, type ButtonOptions } from "../Button.js";
 import stylesButton from "../Button.module.css";
 import { Dialog } from "../Dialog.js";
 
+export type StockButtonOptions = ButtonOptions & ThisType<StockButton>;
+
 export class StockButton extends Button {
-  declare readonly _options: ButtonOptions;
+  declare readonly _options: StockButtonOptions;
   readonly setting: ResourcesSettingsItem;
   readonly resourceName: string;
 
@@ -17,7 +19,7 @@ export class StockButton extends Button {
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
-    options?: ButtonOptions,
+    options?: StockButtonOptions,
   ) {
     super(host, "", null, {
       ...options,

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -49,10 +49,7 @@ export class StockButton extends Button {
           })
           .then(() => {
             this.refreshUi();
-
-            if (options?.onClick) {
-              options.onClick(this);
-            }
+            options?.onClick?.();
           })
           .catch(redirectErrorsToConsole(console));
       },

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -18,7 +18,7 @@ export class StockButton extends Button {
     setting: ResourcesSettingsItem,
     locale: SettingOptions<SupportedLocale>,
     resourceName: string,
-    options?: StockButtonOptions,
+    options: Omit<StockButtonOptions, "onClick">,
   ) {
     super(parent, "", null, {
       ...options,

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -56,6 +56,10 @@ export class StockButton extends Button {
     this.setting = setting;
   }
 
+  toString(): string {
+    return `[${StockButton.name}#${this.componentId}]`;
+  }
+
   refreshUi() {
     super.refreshUi();
 

--- a/source/ui/components/buttons/StockButton.ts
+++ b/source/ui/components/buttons/StockButton.ts
@@ -1,4 +1,3 @@
-import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
 import type { SupportedLocale } from "../../../Engine.js";
 import type { KittenScientists } from "../../../KittenScientists.js";
 import type { ResourcesSettingsItem } from "../../../settings/ResourcesSettings.js";
@@ -23,8 +22,8 @@ export class StockButton extends Button {
   ) {
     super(host, "", null, {
       ...options,
-      onClick: () => {
-        Dialog.prompt(
+      onClick: async () => {
+        const value = await Dialog.prompt(
           host,
           host.engine.i18n("resources.stock.prompt"),
           host.engine.i18n("resources.stock.promptTitle", [
@@ -33,28 +32,24 @@ export class StockButton extends Button {
           ]),
           host.renderAbsolute(setting.stock),
           host.engine.i18n("resources.stock.promptExplainer"),
-        )
-          .then(value => {
-            if (value === undefined) {
-              return;
-            }
+        );
+        if (value === undefined) {
+          return;
+        }
 
-            if (value === "" || value.startsWith("-")) {
-              setting.stock = -1;
-              return;
-            }
+        if (value === "" || value.startsWith("-")) {
+          setting.stock = -1;
+          return;
+        }
 
-            if (value === "0") {
-              setting.enabled = false;
-            }
+        if (value === "0") {
+          setting.enabled = false;
+        }
 
-            setting.stock = host.parseAbsolute(value) ?? setting.stock;
-          })
-          .then(() => {
-            this.refreshUi();
-            options?.onClick?.();
-          })
-          .catch(redirectErrorsToConsole(console));
+        setting.stock = host.parseAbsolute(value) ?? setting.stock;
+
+        this.refreshUi();
+        options?.onClick?.();
       },
     });
 

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -12,15 +12,15 @@ import { Button, type ButtonOptions } from "../Button.js";
 
 export type TriggerButtonBehavior = "integer" | "percentage";
 
-export type TriggerButtonOptions = ButtonOptions & {
-  readonly onRefreshTitle?: (subject: TriggerButton) => void;
-} & ThisType<TriggerButton>;
+export type TriggerButtonOptions = ThisType<TriggerButton> &
+  ButtonOptions & {
+    readonly onRefreshTitle?: () => void;
+  };
 
 export class TriggerButton extends Button {
   declare readonly _options: TriggerButtonOptions;
   readonly behavior: TriggerButtonBehavior;
   readonly setting: SettingTrigger | SettingThreshold;
-  protected readonly _onRefreshTitle?: (subject: TriggerButton) => void;
 
   constructor(
     host: KittenScientists,
@@ -29,8 +29,6 @@ export class TriggerButton extends Button {
     options?: TriggerButtonOptions,
   ) {
     super(host, "", Icons.Trigger, options);
-
-    this._onRefreshTitle = options?.onRefreshTitle;
 
     this.behavior = setting instanceof SettingTrigger ? "percentage" : "integer";
 
@@ -44,8 +42,8 @@ export class TriggerButton extends Button {
   refreshUi() {
     super.refreshUi();
 
-    if (this._onRefreshTitle) {
-      this._onRefreshTitle(this);
+    if (this._options?.onRefreshTitle) {
+      this._options?.onRefreshTitle?.call(this);
       return;
     }
 

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -14,7 +14,7 @@ export type TriggerButtonBehavior = "integer" | "percentage";
 
 export type TriggerButtonOptions = ThisType<TriggerButton> &
   ButtonOptions & {
-    readonly onRefreshTitle?: () => void;
+    readonly onRefreshTitle?: () => void | Promise<void>;
   };
 
 export class TriggerButton extends Button {

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -43,8 +43,7 @@ export class TriggerButton extends Button {
     super.refreshUi();
 
     if (this._options?.onRefreshTitle) {
-      this._options?.onRefreshTitle?.call(this);
-      return;
+      return this._options?.onRefreshTitle?.call(this);
     }
 
     const triggerValue =

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -13,10 +13,11 @@ import { Button, type ButtonOptions } from "../Button.js";
 export type TriggerButtonBehavior = "integer" | "percentage";
 
 export type TriggerButtonOptions = ButtonOptions & {
-  readonly onRefreshTitle: (subject: TriggerButton) => void;
+  readonly onRefreshTitle?: (subject: TriggerButton) => void;
 };
 
 export class TriggerButton extends Button {
+  declare readonly _options: TriggerButtonOptions;
   readonly behavior: TriggerButtonBehavior;
   readonly setting: SettingTrigger | SettingThreshold;
   protected readonly _onRefreshTitle?: (subject: TriggerButton) => void;
@@ -25,7 +26,7 @@ export class TriggerButton extends Button {
     host: KittenScientists,
     setting: SettingTrigger | SettingThreshold,
     _locale: SettingOptions<SupportedLocale>,
-    options?: Partial<TriggerButtonOptions>,
+    options?: TriggerButtonOptions,
   ) {
     super(host, "", Icons.Trigger, options);
 

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -12,7 +12,10 @@ import type { UiComponent } from "../UiComponent.js";
 
 export type TriggerButtonBehavior = "integer" | "percentage";
 
-export type TriggerButtonOptions = ThisType<TriggerButton> & ButtonOptions;
+export type TriggerButtonOptions = ThisType<TriggerButton> &
+  ButtonOptions & {
+    readonly renderLabel?: boolean;
+  };
 
 export class TriggerButton extends Button {
   declare readonly options: TriggerButtonOptions;
@@ -49,6 +52,8 @@ export class TriggerButton extends Button {
         : this.host.renderPercentage(this.setting.trigger, "invariant", true);
 
     this.updateTitle(this.host.engine.i18n("ui.trigger", [triggerValue]));
-    this.updateLabel(triggerValue);
+    if (this.options?.renderLabel ?? true) {
+      this.updateLabel(triggerValue);
+    }
   }
 }

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -12,10 +12,7 @@ import type { UiComponent } from "../UiComponent.js";
 
 export type TriggerButtonBehavior = "integer" | "percentage";
 
-export type TriggerButtonOptions = ThisType<TriggerButton> &
-  ButtonOptions & {
-    readonly onRefreshTitle?: () => void | Promise<void>;
-  };
+export type TriggerButtonOptions = ThisType<TriggerButton> & ButtonOptions;
 
 export class TriggerButton extends Button {
   declare readonly options: TriggerButtonOptions;
@@ -39,11 +36,15 @@ export class TriggerButton extends Button {
     this.setting = setting;
   }
 
+  toString(): string {
+    return `[${TriggerButton.name}#${this.componentId}]`;
+  }
+
   refreshUi() {
     super.refreshUi();
 
-    if (this.options?.onRefreshTitle) {
-      return this.options?.onRefreshTitle?.call(this);
+    if (this.options?.onRefresh) {
+      return;
     }
 
     const triggerValue =

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -40,12 +40,8 @@ export class TriggerButton extends Button {
     return `[${TriggerButton.name}#${this.componentId}]`;
   }
 
-  refreshUi() {
+  refreshUi(): void {
     super.refreshUi();
-
-    if (this.options?.onRefresh) {
-      return;
-    }
 
     const triggerValue =
       this.behavior === "integer"

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -1,7 +1,6 @@
 import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
 import { InvalidOperationError } from "@oliversalzburg/js-utils/errors/InvalidOperationError.js";
 import type { SupportedLocale } from "../../../Engine.js";
-import type { KittenScientists } from "../../../KittenScientists.js";
 import { Icons } from "../../../images/Icons.js";
 import {
   type SettingOptions,
@@ -9,6 +8,7 @@ import {
   SettingTrigger,
 } from "../../../settings/Settings.js";
 import { Button, type ButtonOptions } from "../Button.js";
+import type { UiComponent } from "../UiComponent.js";
 
 export type TriggerButtonBehavior = "integer" | "percentage";
 
@@ -18,17 +18,17 @@ export type TriggerButtonOptions = ThisType<TriggerButton> &
   };
 
 export class TriggerButton extends Button {
-  declare readonly _options: TriggerButtonOptions;
+  declare readonly options: TriggerButtonOptions;
   readonly behavior: TriggerButtonBehavior;
   readonly setting: SettingTrigger | SettingThreshold;
 
   constructor(
-    host: KittenScientists,
+    parent: UiComponent,
     setting: SettingTrigger | SettingThreshold,
     _locale: SettingOptions<SupportedLocale>,
     options?: TriggerButtonOptions,
   ) {
-    super(host, "", Icons.Trigger, options);
+    super(parent, "", Icons.Trigger, options);
 
     this.behavior = setting instanceof SettingTrigger ? "percentage" : "integer";
 
@@ -42,16 +42,16 @@ export class TriggerButton extends Button {
   refreshUi() {
     super.refreshUi();
 
-    if (this._options?.onRefreshTitle) {
-      return this._options?.onRefreshTitle?.call(this);
+    if (this.options?.onRefreshTitle) {
+      return this.options?.onRefreshTitle?.call(this);
     }
 
     const triggerValue =
       this.behavior === "integer"
-        ? this._host.renderAbsolute(this.setting.trigger, "invariant")
-        : this._host.renderPercentage(this.setting.trigger, "invariant", true);
+        ? this.host.renderAbsolute(this.setting.trigger, "invariant")
+        : this.host.renderPercentage(this.setting.trigger, "invariant", true);
 
-    this.updateTitle(this._host.engine.i18n("ui.trigger", [triggerValue]));
+    this.updateTitle(this.host.engine.i18n("ui.trigger", [triggerValue]));
     this.updateLabel(triggerValue);
   }
 }

--- a/source/ui/components/buttons/TriggerButton.ts
+++ b/source/ui/components/buttons/TriggerButton.ts
@@ -14,7 +14,7 @@ export type TriggerButtonBehavior = "integer" | "percentage";
 
 export type TriggerButtonOptions = ButtonOptions & {
   readonly onRefreshTitle?: (subject: TriggerButton) => void;
-};
+} & ThisType<TriggerButton>;
 
 export class TriggerButton extends Button {
   declare readonly _options: TriggerButtonOptions;


### PR DESCRIPTION
Consolidate GUI solutions to allow for refactoring.

Signalling ineffective (default) states to the user required a major rebuild of the UI framework to allow for reactivity. Anything that previously existed in the UI in that area, was purely driven by long function call chains. There is still some of that, but all components now utilize the same solutions, instead of rolling 12 individual ones. All components are now also properly ordered into a parent-child-hierarchy to efficiently determine which elements need to be refreshed. It's a lot of ground work with probably very little effect for the time being, but it was a massive undertaking