### PR TITLE
feat: Unified script loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 default: build
 
-build: devcontainer lib
+build: devcontainer injectable userscript loader lib
 
 clean:
 	rm --force --recursive _site .venv devcontainer/overlay docs/current/public lib node_modules output tsconfig.tsbuildinfo
@@ -36,24 +36,27 @@ devcontainer-oci: devcontainer
 		--tag localhost/devcontainer:latest \
 		.
 
+
 node_modules:
 	yarn install
 
 lib: node_modules
 	yarn tsc --build
 
-output: node_modules
-	yarn vite --config vite.config.userscript.js build
-
-.PHONY: injectable
+.PHONY: injectable userscript loader
 injectable: node_modules
 	yarn vite --config vite.config.inject.js build
+	MINIFY=true yarn vite --config vite.config.inject.js build
 	mkdir -p devcontainer/overlay/ && cp output/kitten-scientists.inject.js devcontainer/overlay/kitten-scientists.inject.js
 
-.PHONY: userscript
 userscript: node_modules
 	yarn vite --config vite.config.userscript.js build
 	MINIFY=true yarn vite --config vite.config.userscript.js build
+
+loader: node_modules injectable
+	yarn vite --config vite.config.loader.js build
+	MINIFY=true yarn vite --config vite.config.loader.js build
+
 
 .venv:
 	python3 -m venv .venv

--- a/source/KittenScientists.ts
+++ b/source/KittenScientists.ts
@@ -14,6 +14,7 @@ import { UserScriptLoader } from "./UserScriptLoader.js";
 import { UserInterface } from "./ui/UserInterface.js";
 
 declare global {
+  const GM: unknown;
   const RELEASE_CHANNEL: ReleaseChannel;
   const RELEASE_VERSION: string | undefined;
 }
@@ -65,7 +66,6 @@ export class KittenScientists {
       this._userInterface = new UserInterface(this);
     } catch (error: unknown) {
       console.error(...cl("Failed to construct core components.", error));
-      // @ts-expect-error Go fuck yourself, really.
       if (typeof GM !== "undefined") {
         console.warn(...cl("Detected running in Greasemonkey."));
       }

--- a/source/entrypoint-loader.ts
+++ b/source/entrypoint-loader.ts
@@ -1,0 +1,24 @@
+import { isNil } from "@oliversalzburg/js-utils/data/nil.js";
+import { redirectErrorsToConsole } from "@oliversalzburg/js-utils/errors/console.js";
+import { InvalidOperationError } from "@oliversalzburg/js-utils/errors/InvalidOperationError.js";
+
+declare global {
+  const PAYLOAD: string;
+}
+
+(async () => {
+  const existingLoader = document.querySelector("#ks-loader-singleton");
+  if (!isNil(existingLoader)) {
+    throw new InvalidOperationError(
+      "The Kitten Science script loader was already created. This is unexpected.",
+    );
+  }
+
+  if (typeof GM !== "undefined") {
+    const nodeScript = document.createElement("script");
+    nodeScript.id = "ks-loader-singleton";
+    nodeScript.textContent = PAYLOAD;
+    nodeScript.type = "application/javascript";
+    document.body.appendChild(nodeScript);
+  }
+})().catch(redirectErrorsToConsole(console));

--- a/vite.config.inject.js
+++ b/vite.config.inject.js
@@ -2,7 +2,9 @@ import { defineConfig } from "vite";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import manifest from "./package.json" with { type: "json" };
 
-const filename = "kitten-scientists.inject.js";
+const MINIFY = Boolean(process.env.MINIFY);
+
+const filename = ["kitten-scientists", MINIFY ? ".min" : "", ".inject.js"].join("");
 
 const RELEASE_CHANNEL = JSON.stringify(process.env.RELEASE_CHANNEL ?? "fixed");
 const RELEASE_VERSION = JSON.stringify(process.env.RELEASE_VERSION ?? `${manifest.version}-live`);
@@ -14,7 +16,7 @@ export default defineConfig({
       entry: "source/entrypoint-userscript.ts",
       name: "kitten-scientists",
     },
-    minify: false,
+    minify: MINIFY ? "esbuild" : false,
     outDir: "output",
     rollupOptions: {
       external: ["dojo", "jquery"],

--- a/vite.config.loader.js
+++ b/vite.config.loader.js
@@ -1,47 +1,51 @@
-import cleanup from "rollup-plugin-cleanup";
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vite";
-import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import { metablock } from "vite-plugin-userscript";
 import manifest from "./package.json" with { type: "json" };
 
-const minify = Boolean(process.env.MINIFY);
+const minify = Boolean(process.env.MINIFY) ?? !isDevBuild;
 const versionString = process.env.RELEASE_VERSION ?? "0.0.0-ci";
 
-const filename = ["kitten-scientists", `-${versionString}`, minify ? ".min" : "", ".user.js"].join(
-  "",
-);
+const filename = [
+  "kitten-scientists-loader",
+  `-${versionString}`,
+  minify ? ".min" : "",
+  ".user.js",
+].join("");
 
 const RELEASE_CHANNEL = process.env.RELEASE_CHANNEL ?? "fixed";
-const RELEASE_VERSION = versionString;
 
 const downloadURL = `https://kitten-science.com/${RELEASE_CHANNEL}.js`;
 const updateURL = `https://kitten-science.com/${RELEASE_CHANNEL}.min.js`;
+
+const PAYLOAD = JSON.stringify(
+  readFileSync(
+    minify ? "./output/kitten-scientists.min.inject.js" : "./output/kitten-scientists.inject.js",
+    "utf-8",
+  ).replace(/\/\/# sourceMappingURL=.+/, ""),
+);
 
 export default defineConfig({
   build: {
     emptyOutDir: false,
     lib: {
-      entry: "source/entrypoint-userscript.ts",
+      entry: "source/entrypoint-loader.ts",
       name: "kitten-scientists",
     },
     minify: minify ? "esbuild" : false,
     outDir: "output",
     rollupOptions: {
-      external: ["dojo", "jquery"],
       output: {
         entryFileNames: filename,
         extend: true,
         format: "umd",
       },
-      plugins: [cleanup({ comments: "none", extensions: ["js", "ts"] })],
     },
   },
   define: {
-    RELEASE_CHANNEL: JSON.stringify(RELEASE_CHANNEL),
-    RELEASE_VERSION: JSON.stringify(RELEASE_VERSION),
+    PAYLOAD,
   },
   plugins: [
-    cssInjectedByJsPlugin({ styleId: "ks-styles", topExecutionPriority: false }),
     {
       ...metablock({
         override: {
@@ -52,7 +56,6 @@ export default defineConfig({
           version: versionString,
         },
       }),
-      enforce: "post",
     },
   ],
 });


### PR DESCRIPTION
Ideally, by always only performing a very thin injection of a `script` node into the DOM, just like with the bookmarklet, we can unify all script loading approaches, and potentially solve GreaseMonkey integration issues.

Initial testing confirms that the new loader works with GreaseMonkey.