### PR TITLE
fix: display KS UI position correctly after loading

### DIFF
--- a/source/ui/StateManagementUi.ts
+++ b/source/ui/StateManagementUi.ts
@@ -703,7 +703,13 @@ export class StateManagementUi extends SettingsPanel<StateSettings> {
 		}
 
 		console.info(...cl("Loading Auto-Save..."));
-		this.host.engine.stateLoad(existing.unwrap().state, false);
+		const state = existing.unwrap().state;
+		const requiresUiRebuild =
+			this.host.engine.settings.ksColumn.enabled !== state.engine.ksColumn.enabled;
+		this.host.engine.stateLoad(state, false);
+		if (requiresUiRebuild) {
+			this.host.rebuildUi();
+		}
 	}
 
 	updateGame(game: Unique<StoredGame>, newGame: KGSaveData) {


### PR DESCRIPTION
When loading the KS while the Internals toggle "Display KS in fourth column in UI" was saved with "on" state, the KS still displays above the log, instead of being rendered as 4th column. In short - the setting is remembered, but is not loaded properly on KS initialization. This fixes it.