### PR TITLE
feat: Cross out researched items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 output/
 .npmrc
 tsconfig.tsbuildinfo
+.DS_Store

--- a/source/ui/PolicySettingsUi.ts
+++ b/source/ui/PolicySettingsUi.ts
@@ -57,6 +57,12 @@ export class PolicySettingsUi extends SettingsPanel<PolicySettings> {
 				onCheck: () => {
 					this.host.engine.imessage("status.sub.enable", [policy.label]);
 				},
+				onRefresh: () => {
+					element.element.toggleClass(
+						stylesLabelListItem.researched,
+						policy.researched,
+					);
+				},
 				onUnCheck: () => {
 					this.host.engine.imessage("status.sub.disable", [policy.label]);
 				},

--- a/source/ui/TechSettingsUi.ts
+++ b/source/ui/TechSettingsUi.ts
@@ -128,6 +128,10 @@ export class TechSettingsUi extends SettingsPanel<
 							option.enabled &&
 							settings.trigger === -1 &&
 							option.trigger === -1;
+						element.element.toggleClass(
+							stylesLabelListItem.researched,
+							tech.researched,
+						);
 					},
 					onRefreshTrigger: () => {
 						element.triggerButton.element[0].title = this.host.engine.i18n(

--- a/source/ui/UpgradeSettingsUi.ts
+++ b/source/ui/UpgradeSettingsUi.ts
@@ -118,6 +118,12 @@ export class UpgradeSettingsUi extends SettingsPanel<
 					onCheck: () => {
 						this.host.engine.imessage("status.sub.enable", [upgrade.label]);
 					},
+					onRefresh: () => {
+						element.element.toggleClass(
+							stylesLabelListItem.researched,
+							upgrade.researched === true,
+						);
+					},
 					onRefreshRequest: () => {
 						element.triggerButton.inactive =
 							!option.enabled || option.trigger === -1;

--- a/source/ui/components/LabelListItem.module.css
+++ b/source/ui/components/LabelListItem.module.css
@@ -17,6 +17,11 @@
 	font-weight: bold;
 }
 
+.researched .label {
+	text-decoration: line-through;
+	opacity: 0.5;
+}
+
 .iconLabel {
 	display: inline-block;
 	margin-right: 4px;


### PR DESCRIPTION
I find it a bit annoying needing to figure out by myself which tech, upgrades and policies I have already researched when going through long list of them in KS. We can use information what was already researched and cross out those elements in KS. Here's how it looks like:

<img width="199" height="187" alt="image" src="https://github.com/user-attachments/assets/4cf788bb-c015-4bdc-a149-30ce5ee4e7e1" />

This way I can easily tell which checked tech is still to be completed, and which I don't need to bother about. It also gives a nice feeling of completion when skimming the list full of crossed-out positions.