### PR TITLE
fix(village): respect manpower reserve when auto-hunting

### DIFF
--- a/source/VillageManager.ts
+++ b/source/VillageManager.ts
@@ -242,8 +242,19 @@ export class VillageManager implements Automation {
 			return;
 		}
 
-		// Determine how many hunts are being performed.
-		const huntCount = Math.floor(manpower.value / 100);
+		// The manpower cost of a single hunt, accounting for any catpower discount.
+		const manpowerCost =
+			100 - this._host.game.getEffect("huntCatpowerDiscount");
+
+		// Determine how many hunts are being performed, while respecting the
+		// configured manpower reserve. `getValueAvailable` subtracts the reserve
+		// (resource stock), so we never spend manpower below it.
+		const manpowerAvailable =
+			this._workshopManager.getValueAvailable("manpower");
+		const huntCount = Math.floor(manpowerAvailable / manpowerCost);
+		if (huntCount < 1) {
+			return;
+		}
 		this._host.engine.storeForSummary("hunt", huntCount);
 
 		const averageOutput = this._workshopManager.getAverageHunt();
@@ -272,8 +283,12 @@ export class VillageManager implements Automation {
 			});
 		}
 
-		// Now actually perform the hunts.
-		this._host.game.village.huntAll();
+		// Now actually perform the hunts. We can't use `village.huntAll`, as that
+		// always spends *all* available manpower and ignores our reserve. Instead
+		// we replicate its behavior (see the game's `huntFraction`) for a bounded
+		// number of squads, leaving the configured reserve untouched.
+		this._host.game.resPool.addResEvent("manpower", -huntCount * manpowerCost);
+		this._host.game.village.gainHuntRes(huntCount);
 		this._host.engine.iactivity(
 			"act.hunt",
 			[this._host.renderAbsolute(huntCount)],


### PR DESCRIPTION
## Problem

When auto-hunt is enabled, it always drains catpower (manpower) to zero,
ignoring the configured **manpower reserve** (the resource *stock* set on
the Resources tab).

Root cause is in `VillageManager.autoHunt`:

- The hunt count is derived from the **raw** `manpower.value` rather than
  the reserve-aware available amount.
- It then calls the game's `village.huntAll()`, which internally is
  `huntFraction(1)` and always spends **all** affordable manpower.

So the reserve — which trading and crafting honor via
`WorkshopManager.getValueAvailable` — has no effect on hunting.

## Fix

- Compute the hunt count from `getValueAvailable("manpower")`, which
  subtracts the reserve (stock) and applies the consume rate, instead of
  the raw value.
- Account for the per-hunt catpower discount via
  `getEffect("huntCatpowerDiscount")`.
- Replace `village.huntAll()` with a bounded replication of the game's
  `huntFraction` logic: deduct exactly `huntCount * manpowerCost` and call
  `village.gainHuntRes(huntCount)`, leaving the configured reserve
  untouched.
- Bail out early when the affordable hunt count drops below one after the
  reserve is applied.

## Verification

- `tsc --build` passes (exit 0).
- `biome check` passes.

No automated test added: the repo has no unit-test harness for the
managers (tests run as a production build), and the fix mirrors the
game's own `huntFraction` implementation. Behavioral check in-game: set a
manpower reserve, enable auto-hunt, and confirm catpower now stops at the
reserve instead of hitting zero.