### PR TITLE
fix(i18n): Persist language selection across reloads

### DIFF
--- a/source/Engine.ts
+++ b/source/Engine.ts
@@ -68,6 +68,14 @@ import { WorkshopManager } from "./WorkshopManager.js";
 
 const i18nData = { "de-DE": deDE, "en-US": enUS, "he-IL": heIL, "zh-CN": zhCN };
 
+/**
+ * Web storage key under which the user's explicitly selected language is
+ * persisted. This is stored independently from the engine state, so the
+ * language choice survives a page reload even before the game has written
+ * the engine state into its save data.
+ */
+const LOCALE_STORAGE_KEY = "ks.locale";
+
 export type FrameContext = {
 	purchaseOrders: Array<{
 		builds: Partial<
@@ -177,7 +185,14 @@ export class Engine {
 		this.settings = new EngineSettings();
 
 		this._i18nData = i18nData;
-		this.setLanguage(gameLanguage, false);
+		// Prefer the language the user explicitly selected in a previous session
+		// over the game's current language.
+		const persistedLocale = this._loadPersistedLocale();
+		if (!isNil(persistedLocale)) {
+			this.setLocale(persistedLocale, false);
+		} else {
+			this.setLanguage(gameLanguage, false);
+		}
 
 		this._host = host;
 		this._activitySummary = new ActivitySummary(this._host);
@@ -269,6 +284,43 @@ export class Engine {
 	}
 
 	/**
+	 * Persists the currently selected language to web storage, so it can be
+	 * restored on the next page load, regardless of whether the game has saved
+	 * the engine state yet.
+	 *
+	 * @param locale The locale to persist. Defaults to the currently selected one.
+	 */
+	persistLocale(locale = this.settings.locale.selected): void {
+		try {
+			UserScriptLoader.window.localStorage[LOCALE_STORAGE_KEY] = locale;
+		} catch (error) {
+			console.warn(...cl("Failed to persist the selected language.", error));
+		}
+	}
+
+	/**
+	 * Reads the user's explicitly selected language from web storage, if any.
+	 *
+	 * @returns The persisted locale, or `undefined` if none was persisted or it
+	 * is no longer supported.
+	 */
+	private _loadPersistedLocale(): SupportedLocale | undefined {
+		let stored: string | undefined;
+		try {
+			stored = UserScriptLoader.window.localStorage[LOCALE_STORAGE_KEY] as
+				| string
+				| undefined;
+		} catch (error) {
+			console.warn(...cl("Failed to read the persisted language.", error));
+			return undefined;
+		}
+
+		return !isNil(stored) && this.isLocaleSupported(stored)
+			? (stored as SupportedLocale)
+			: undefined;
+	}
+
+	/**
 	 * Loads a new state into the engine.
 	 *
 	 * @param settings The engine state to load.
@@ -336,7 +388,10 @@ export class Engine {
 			this.workshopManager.settings.load(settings.workshop);
 		}, "workshop");
 
-		this.setLocale(this.settings.locale.selected);
+		// The user's explicitly selected language takes precedence over whatever
+		// locale was stored in the (potentially stale) engine state.
+		const persistedLocale = this._loadPersistedLocale();
+		this.setLocale(persistedLocale ?? this.settings.locale.selected);
 
 		// Ensure the main engine setting is respected.
 		if (this.settings.enabled) {

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -119,6 +119,10 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
 					settings.locale,
 					{
 						onCheck: () => {
+							// Persist the choice right away, so it survives a reload even
+							// before the game's next auto-save. Our `game/beforesave`
+							// handler injects the KS engine state into the save data.
+							parent.host.game.save();
 							parent.host.rebuildUi();
 						},
 					},

--- a/source/ui/InternalsUi.ts
+++ b/source/ui/InternalsUi.ts
@@ -119,6 +119,9 @@ export class InternalsUi extends SettingsPanel<EngineSettings> {
 					settings.locale,
 					{
 						onCheck: () => {
+							// Persist the choice immediately, so it survives a page
+							// reload even before the game saves the engine state.
+							parent.host.engine.persistLocale();
 							parent.host.rebuildUi();
 						},
 					},


### PR DESCRIPTION
## Problem

Selecting a language in the KS UI (Internals → Language) only updated `settings.locale.selected` in memory and rebuilt the UI. That choice was only written to storage on the game's next `game/beforesave`. On page reload, the initial locale was taken from the *game's* language and then overwritten by the (potentially stale) engine state embedded in the game save — so a fresh language choice that hadn't been game-saved yet was lost, reverting to English.

## Fix

Persist the user's explicit language choice to a dedicated `ks.locale` web storage key (independent of the engine state) the moment it is selected, and treat it as the authoritative source on load:

- **`Engine`**: add `persistLocale()` / `_loadPersistedLocale()` helpers (guarded with try/catch) and a `LOCALE_STORAGE_KEY` constant.
- **Engine constructor**: seed the initial locale from the persisted choice, falling back to the game language when none exists.
- **`Engine.stateLoad()`**: let the persisted locale override the locale stored in a (possibly stale) engine state.
- **`InternalsUi`**: call `persistLocale()` in the language option's `onCheck`, so the choice is stored immediately.

## Behavior

- Pick a language → it is stored at once → it survives a reload regardless of game-save timing.
- New users with no `ks.locale` keep the previous behavior of following the game language.
- A corrupt/unsupported stored value falls back safely.

Note: because the user's explicit language choice now takes precedence, importing someone else's settings no longer changes the UI language (the language preference is "sticky"). This seems correct for a language preference, but happy to adjust if the project prefers imports to override it.

## Verification

- `make lint` (`biome check .` + `tsc --noEmit`) passes.
- Manually verified in-game: set language to Chinese, reload immediately → stays Chinese.