### PR TITLE
fix for KG 1.5.0.3: add new craftable resources & new job

### DIFF
--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -525,8 +525,10 @@ export const ResourcesCraftable = [
 	"kerosene",
 	"manuscript",
 	"megalith",
+	"microchip",
 	"parchment",
 	"plate",
+	"plastic",
 	"scaffold",
 	"ship",
 	"slab",
@@ -594,6 +596,7 @@ export type TabId = (typeof TabIds)[number];
 
 export const Jobs = [
 	"any",
+	"ambassador",
 	"engineer",
 	"farmer",
 	"geologist",


### PR DESCRIPTION
they just updated Kittens Game to 1.5.0.3, which broke Kitten Scientists because the update added new craftable resources & a new job. this PR adds the 2 new craftables and the new job so KS can continue to function.

KS would attempt to do its things once then stop doing anything, with an error in the console:

`TypeError: can't access property "enabled", l is undefined`

once i added the 2 craftables & had a free kitten, i got a similar error about a job being undefined, so i debugged and found what it was called and added it to the jobs list. i don't have this job unlocked in my game, but the error no longer shows up & breaks KS.

also, auto crafting the new resources with KS works fine.

the KG update added more things that KS reports:
```The religion building 'darkParacosm' is not tracked in Kitten Scientists!
The workshop upgrade 'freightfulExchange' is not tracked in Kitten Scientists! 
The workshop upgrade 'transportSuperposition' is not tracked in Kitten Scientists!
The workshop upgrade 'prospecting' is not tracked in Kitten Scientists!
The workshop upgrade 'petri' is not tracked in Kitten Scientists!
```

this PR does not attempt to add those or any other new functionality as a result of the update, it just makes sure that KS doesn't error out and can continue to function (partly because i don't have all of them unlocked in my game yet so i can't test).